### PR TITLE
Add forecast zone and foreshadow debug button (#356)

### DIFF
--- a/innovation.action.php
+++ b/innovation.action.php
@@ -78,6 +78,12 @@
         $this->game->debug_dig($card_id);
         self::ajaxResponse();
     }
+    public function debug_foreshadow() {            
+        self::setAjaxMode();
+        $card_id = self::getArg("card_id", AT_posint, true);
+        $this->game->debug_foreshadow($card_id);
+        self::ajaxResponse();
+    }
     //******
       
     public function initialMeld() {

--- a/innovation.css
+++ b/innovation.css
@@ -178,7 +178,7 @@
   display: inline-block;
   position: relative;
 }
-.forecast_container > p {
+.forecast_container p {
   font-style: italic;
   font-size: 0.8em;
   position: absolute;
@@ -196,7 +196,7 @@
   display: inline-block;
   position: relative;
 }
-.score_container > p {
+.score_container p {
   font-style: italic;
   font-size: 0.8em;
   position: absolute;

--- a/innovation.css
+++ b/innovation.css
@@ -172,6 +172,24 @@
   margin-top: 30px;
 }
 
+.forecast_container {
+  flex-grow: 1;
+  vertical-align: top;
+  display: inline-block;
+  position: relative;
+}
+.forecast_container > p {
+  font-style: italic;
+  font-size: 0.8em;
+  position: absolute;
+  top: 0px;
+  margin: 0px;
+  right: 3px;
+  height: 16px;
+  overflow-y: hidden;
+  text-align: right;
+}
+
 .score_container {
   flex-grow: 1;
   vertical-align: top;
@@ -239,6 +257,13 @@
   overflow-y: hidden;
 }
 
+.forecast {
+  display: inline-block;
+  margin-top: 18px;
+  display: inline-block;
+  height: 49px;
+}
+
 .score {
   display: inline-block;
   margin-top: 18px;
@@ -251,6 +276,14 @@
   margin-top: 18px;
   display: inline-block;
   height: 49px;
+}
+
+.forecast_show_window {
+  text-decoration: underline;
+  font-weight: bold;
+}
+.forecast_show_window:hover {
+  cursor: pointer;
 }
 
 .score_show_window {

--- a/innovation.css
+++ b/innovation.css
@@ -43,7 +43,7 @@
 }
 
 .debug_button {
-  width: 100px;
+  width: 150px;
 }
 
 .card_name {
@@ -184,10 +184,10 @@
   position: absolute;
   top: 0px;
   margin: 0px;
-  right: 3px;
+  left: 3px;
   height: 16px;
   overflow-y: hidden;
-  text-align: right;
+  text-align: left;
 }
 
 .score_container {
@@ -667,6 +667,7 @@
 .two_lines {
   top: -16px !important;
   height: 32px !important;
+  padding-right: 3px;
 }
 
 .sep {

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -371,6 +371,32 @@ class Innovation extends Table
             throw new BgaUserException(self::format("This card is in {player_name}'s {location}", array('player_name' => self::getPlayerNameFromId($card['owner']), 'location' => $card['location'])));
         }
     }
+    function debug_foreshadow($card_id) {
+        if (self::getGameStateValue('debug_mode') == 0) {
+            return; // Not in debug mode
+        }
+        $player_id = self::getCurrentPlayerId();
+        $card = self::getCardInfo($card_id);
+        if ($card['location'] == 'achievements') {
+            throw new BgaUserException("This card is used as an achievement");
+        } else if ($card['location'] == 'relics') {
+            throw new BgaUserException("This card is used as a relic");
+        } else if ($card['location'] == 'removed') {
+            throw new BgaUserException("This card is removed from the game");
+        } else if ($card['location'] == 'deck') {
+            try {
+                self::transferCardFromTo($card, $player_id, "forecast");
+            }
+            catch (EndOfGame $e) {
+                // End of the game: the exception has reached the highest level of code
+                self::trace('EOG bubbled from self::debug_foreshadow');
+                $this->gamestate->nextState('justBeforeGameEnd');
+                return;
+            }
+        } else {
+            throw new BgaUserException(self::format("This card is in {player_name}'s {location}", array('player_name' => self::getPlayerNameFromId($card['owner']), 'location' => $card['location'])));
+        }
+    }
     //******
     
     /*
@@ -702,6 +728,16 @@ class Innovation extends Table
             for ($is_relic = 0; $is_relic <= 1; $is_relic++) {
                 foreach ($players as $player_id => $player) {
                     $result['hand_counts'][$player_id][$type][$is_relic] = self::countCardsInLocationKeyedByAge($player_id, 'hand', $type, $is_relic);
+                }
+            }
+        }
+
+        // Backs of the cards in forecast piles
+        $result['forecast_counts'] = array();
+        for ($type = 0; $type <= 4; $type++) {
+            for ($is_relic = 0; $is_relic <= 1; $is_relic++) {
+                foreach ($players as $player_id => $player) {
+                    $result['forecast_counts'][$player_id][$type][$is_relic] = self::countCardsInLocationKeyedByAge($player_id, 'forecast', $type, $is_relic);
                 }
             }
         }
@@ -1326,6 +1362,7 @@ class Innovation extends Table
             $filter_from .= self::format(" AND type = {type} AND age = {age}", array('type' => $type, 'age' => $age));
             break;
         case 'hand':
+        case 'forecast':
         case 'score':
         case 'relics':
             $filter_from .= self::format(" AND type = {type} AND age = {age} AND is_relic = {is_relic}", array('type' => $type, 'age' => $age, 'is_relic' => $is_relic));
@@ -1344,6 +1381,7 @@ class Innovation extends Table
             $filter_to .= self::format(" AND type = {type} AND age = {age}", array('type' => $type, 'age' => $age));
             break;
         case 'hand':
+        case 'forecast':
         case 'score':
         case 'relics':
             $filter_to .= self::format(" AND type = {type} AND age = {age} AND is_relic = {is_relic}", array('type' => $type, 'age' => $age, 'is_relic' => $is_relic));
@@ -1945,6 +1983,10 @@ class Innovation extends Table
                 $message_for_player = clienttranslate('${You} draw and meld ${<}${age}${>} ${<<}${name}${>>}.');
                 $message_for_others = clienttranslate('${player_name} draws and melds ${<}${age}${>} ${<<}${name}${>>}.');
             }
+            break;
+        case 'deck->forecast':
+            $message_for_player = clienttranslate('${You} draw and foreshadow ${<}${age}${>} ${<<}${name}${>>}.');
+            $message_for_others = clienttranslate('${player_name} draws and foreshadows a ${<}${age}${>}.');
             break;
         case 'deck->score':
             $message_for_player = clienttranslate('${You} draw and score ${<}${age}${>} ${<<}${name}${>>}.');

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -807,10 +807,8 @@ class Innovation extends Table
         }
         
         // Private information
-        // My hand
         $result['my_hand'] = self::flatten(self::getCardsInLocationKeyedByAge($current_player_id, 'hand'));
-        
-        // My score
+        $result['my_forecast'] = self::flatten(self::getCardsInLocationKeyedByAge($current_player_id, 'forecast'));
         $result['my_score'] = self::flatten(self::getCardsInLocationKeyedByAge($current_player_id, 'score'));
         
         // My wish for splay

--- a/innovation.js
+++ b/innovation.js
@@ -335,7 +335,7 @@ function (dojo, declare) {
             
             this.num_cards_in_row.achievements = num_of_achievments_per_row;
             this.num_cards_in_row.score = parseInt((score_width + this.delta.score.x - this.card_dimensions['S card'].width) / (this.delta.score.x));
-            // TODO(ECHOES): Revise this logic to properly incorporate Forecast zone in the calculations.
+            // TODO(https://github.com/micahstairs/bga-innovation/issues/422): Revise this logic to properly incorporate Forecast zone in the calculations.
             this.num_cards_in_row.forecast =  this.num_cards_in_row.score;
 
             // Defining the number of cards the window for forecast verso can host

--- a/innovation.js
+++ b/innovation.js
@@ -209,6 +209,17 @@ function (dojo, declare) {
                 this, function (result) { }, function (is_error) {}
             );      
         },
+        debug_foreshadow: function () {
+            var debug_card_list = document.getElementById("debug_card_list");
+            self = this;
+            this.ajaxcall("/innovation/innovation/debug_foreshadow.html",
+                {
+                    lock: true,
+                    card_id: debug_card_list.value
+                },
+                this, function (result) { }, function (is_error) {}
+            );      
+        },
         //******
                 
         /*
@@ -229,6 +240,9 @@ function (dojo, declare) {
             //****** CODE FOR DEBUG MODE
             if (!this.isSpectator && gamedatas.debug_mode == 1) {
                 var main_area = $('main_area');
+                if (gamedatas.echoes_expansion_enabled) {
+                    main_area.innerHTML = "<button id='debug_foreshadow' class='action-button debug_button bgabutton bgabutton_red'>FORESHADOW</button>" + main_area.innerHTML;
+                }
                 if (gamedatas.artifacts_expansion_enabled) {
                     main_area.innerHTML = "<button id='debug_dig' class='action-button debug_button bgabutton bgabutton_red'>DIG</button>" + main_area.innerHTML;
                 }
@@ -254,12 +268,15 @@ function (dojo, declare) {
                 if (gamedatas.artifacts_expansion_enabled) {
                     dojo.connect($('debug_dig'), 'onclick', this, 'debug_dig');
                 }
+                if (gamedatas.echoes_expansion_enabled) {
+                    dojo.connect($('debug_foreshadow'), 'onclick', this, 'debug_foreshadow');
+                }
 
             }
             //******
         
             this.my_score_verso_window = new dijit.Dialog({ 'title': _("Cards in your score pile (opponents cannot see this)") });
-            this.my_forecast_verso_window = new dijit.Dialog({ 'title': _("Cards in your forecast pile (opponents cannot see this)") });
+            this.my_forecast_verso_window = new dijit.Dialog({ 'title': _("Cards in your forecast (opponents cannot see this)") });
             this.text_for_expanded_mode = _("Show compact");
             this.text_for_compact_mode = _("Show expanded");
             this.text_for_view_normal = _("Look at all cards in piles");
@@ -299,11 +316,11 @@ function (dojo, declare) {
             this.num_cards_in_row.my_hand = parseInt((dojo.contentBox('hand_container_' + any_player_id).w + this.delta.my_hand.x - this.card_dimensions['M card'].width - 10) / (this.delta.my_hand.x));
             this.num_cards_in_row.opponent_hand = parseInt((dojo.contentBox('hand_container_' + any_player_id).w + this.delta.opponent_hand.x - this.card_dimensions['S card'].width - 10) / (this.delta.opponent_hand.x));
             
-
             // Add achievements to win to achievement container and determin max cards per row for the achievement container
             for(var player_id in this.players) {
                 dojo.addClass('achievement_container_' + player_id, 'to_win_' + this.number_of_achievements_needed_to_win)
             }
+
             var achievement_container_width = dojo.position('achievement_container_' + any_player_id).w
             var reference_card_width = dojo.position('reference_card_' + any_player_id).w;
             var progress_width = dojo.position('progress_' + any_player_id).w;
@@ -318,6 +335,15 @@ function (dojo, declare) {
             
             this.num_cards_in_row.achievements = num_of_achievments_per_row;
             this.num_cards_in_row.score = parseInt((score_width + this.delta.score.x - this.card_dimensions['S card'].width) / (this.delta.score.x));
+            // TODO(ECHOES): Revise this logic to properly incorporate Forecast zone in the calculations.
+            this.num_cards_in_row.forecast =  this.num_cards_in_row.score;
+
+            // Defining the number of cards the window for forecast verso can host
+            // Viewport size defined as minimum between the width of a hand container and the width needed to host 6 cards.
+            this.num_cards_in_row.my_forecast_verso = parseInt((dojo.contentBox('hand_container_' + any_player_id).w + this.delta.my_forecast_verso.x - this.card_dimensions['M card'].width) / (this.delta.my_forecast_verso.x));
+            if (this.num_cards_in_row.my_forecast_verso > 6) {
+                this.num_cards_in_row.my_forecast_verso = 6;
+            }
             
             // Defining the number of cards the window for score verso can host
             // Viewport size defined as minimum between the width of a hand container and the width needed to host 6 cards.
@@ -518,6 +544,27 @@ function (dojo, declare) {
                     this.addTooltipForCard(card);
                 }
             }
+
+            // PLAYERS' FORECAST
+            this.zone.forecast = {};
+            for (var player_id in this.players) {
+                // Creation of the zone
+                this.zone.forecast[player_id] = this.createZone('forecast', player_id, null, null, null, grouped_by_age_type_and_is_relic=true);
+                this.setPlacementRules(this.zone.forecast[player_id], left_to_right=true);
+                    
+                // Add cards to zone according to the current situation
+                for (var type = 0; type <= 4; type++) {
+                    for (var is_relic = 0; is_relic <= 1; is_relic++) {
+                        var forecast_count = gamedatas.forecast_counts[player_id][type][is_relic];
+                        for (var age = 1; age <= 10; age++) {
+                            var num_cards = forecast_count[age];
+                            for(var i = 0; i < num_cards; i++) {
+                                this.createAndAddToZone(this.zone.forecast[player_id], i, age, type, is_relic, null, dojo.body(), null);
+                            }
+                        }
+                    }
+                }
+            }
             
             // PLAYERS' SCORE
             this.zone.score = {};
@@ -594,9 +641,9 @@ function (dojo, declare) {
             
             if (!this.isSpectator) {
                 dojo.query('#progress_' + this.player_id + ' .forecast_container > p, #progress_' + this.player_id + ' .achievement_container > p').addClass('two_lines');
-                dojo.query('#progress_' + this.player_id + ' .forecast_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(click to look at the cards)') + '</span>';
+                dojo.query('#progress_' + this.player_id + ' .forecast_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(view cards)') + '</span>';
                 dojo.query('#progress_' + this.player_id + ' .score_container > p, #progress_' + this.player_id + ' .achievement_container > p').addClass('two_lines');
-                dojo.query('#progress_' + this.player_id + ' .score_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(click to look at the cards)') + '</span>';
+                dojo.query('#progress_' + this.player_id + ' .score_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(view cards)') + '</span>';
                 dojo.query('#progress_' + this.player_id + ' .achievement_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(${n} needed to win)').replace('${n}', gamedatas.number_of_achievements_needed_to_win) + '</span>';
             }
             
@@ -1918,6 +1965,7 @@ function (dojo, declare) {
                     return this.zone.relics[0];
                 case "hand":
                 case "display":
+                case "forecast":
                 case "score":
                 case "revealed":
                 case "achievements":
@@ -3331,6 +3379,17 @@ function (dojo, declare) {
         notif_transferedCard : function(notif) {
             var card = notif.args;
 
+            console.log(card);
+
+            // Special code for my forecast management
+            if (card.location_from == "forecast" && card.owner_from == this.player_id) {
+                // Remove the card from my forecast personal window
+                // NOTE: The button to look at the player's forecast is broken in archive mode.
+                if (!g_archive_mode) {
+                    this.removeFromZone(this.zone.my_forecast_verso, card.id, true, card.age, card.type, card.is_relic);
+                }
+            }
+
             // Special code for my score management
             if (card.location_from == "score" && card.owner_from == this.player_id) {
                 // Remove the card from my score personal window
@@ -3433,6 +3492,16 @@ function (dojo, declare) {
             }
 
             this.moveBetweenZones(zone_from, zone_to, id_from, id_to, card);
+
+            // Special code for my forecast management
+            if (card.location_to == "forecast" && card.owner_to == this.player_id) {
+                // Add the card to my forecast personal window
+                // NOTE: The button to look at the player's forecast is broken in archive mode.
+                if (!g_archive_mode) {
+                    this.createAndAddToZone(this.zone.my_forecast_verso, card.position_to, card.age, card.type, card.is_relic, card.id, dojo.body(), card);
+                }
+                visible_to = true;
+            }
             
             // Special code for my score management
             if (card.location_to == "score" && card.owner_to == this.player_id) {
@@ -3612,12 +3681,17 @@ function (dojo, declare) {
 
         notif_removedPlayer: function(notif) {
             var player_id = notif.args.player_to_remove;
+            // NOTE: The button to look at the player's forecast is broken in archive mode.
+            if (!g_archive_mode) {
+                this.zone.my_forecast_verso.removeAll();
+            }
             // NOTE: The button to look at the player's score pile is broken in archive mode.
             if (!g_archive_mode) {
                 this.zone.my_score_verso.removeAll();
             }
             this.zone.revealed[player_id].removeAll();
             this.zone.hand[player_id].removeAll();
+            this.zone.forecast[player_id].removeAll();
             this.zone.score[player_id].removeAll();
             this.zone.achievements[player_id].removeAll();
             this.zone.display[player_id].removeAll();

--- a/innovation.js
+++ b/innovation.js
@@ -55,6 +55,8 @@ function (dojo, declare) {
             this.HTML_class.display = "M card";
             this.HTML_class.deck = "S recto";
             this.HTML_class.board = "M card";
+            this.HTML_class.forecast = "S recto";
+            this.HTML_class.my_forecast_verso = "M card";
             this.HTML_class.score = "S recto";
             this.HTML_class.my_score_verso = "M card";
             this.HTML_class.revealed = "M card";
@@ -68,6 +70,8 @@ function (dojo, declare) {
             this.num_cards_in_row.opponent_hand = null;
             this.num_cards_in_row.display = 1;
             this.num_cards_in_row.deck = 15;
+            this.num_cards_in_row.forecast = null;
+            this.num_cards_in_row.my_forecast_verso = null;
             this.num_cards_in_row.score = null;
             this.num_cards_in_row.my_score_verso = null;
             // For board, this.num_cards_in_row is not defined because it's managed by the splay system: the width is defined dynamically
@@ -81,6 +85,8 @@ function (dojo, declare) {
             this.delta.opponent_hand = {"x": 35, "y": 49}; // + 2
             this.delta.display = {"x": 189, "y": 133}; // +7
             this.delta.deck = {"x": 3, "y": 3}; // overlap
+            this.delta.forecast = {"x": 35, "y": 49}; // + 2
+            this.delta.my_forecast_verso = {"x": 189, "y": 133}; // +7
             this.delta.score = {"x": 35, "y": 49}; // + 2
             this.delta.my_score_verso = {"x": 189, "y": 133}; // +7
             // For board, this.delta is not defined because it's managed by the splay system: the width is defined dynamically
@@ -253,6 +259,7 @@ function (dojo, declare) {
             //******
         
             this.my_score_verso_window = new dijit.Dialog({ 'title': _("Cards in your score pile (opponents cannot see this)") });
+            this.my_forecast_verso_window = new dijit.Dialog({ 'title': _("Cards in your forecast pile (opponents cannot see this)") });
             this.text_for_expanded_mode = _("Show compact");
             this.text_for_compact_mode = _("Show expanded");
             this.text_for_view_normal = _("Look at all cards in piles");
@@ -532,21 +539,37 @@ function (dojo, declare) {
                     }
                 }
             }
+
+            // My forecast: create an extra zone to show the versos of the cards at will in a windows
+            if (!this.isSpectator) {
+                this.my_forecast_verso_window.attr("content", "<div id='my_forecast_verso'></div><a id='forecast_close_window' class='bgabutton bgabutton_blue'>Close</a>");
+                this.zone.my_forecast_verso = this.createZone('my_forecast_verso', this.player_id, null, null, null, grouped_by_age_type_and_is_relic=true);
+                this.setPlacementRules(this.zone.my_forecast_verso, left_to_right=true);
+                for (var i = 0; i < gamedatas.my_forecast.length; i++) {
+                    var card = gamedatas.my_forecast[i];
+                    this.createAndAddToZone(this.zone.my_forecast_verso, card.position, card.age, card.type, card.is_relic, card.id, dojo.body(), card);
+                    // Add tooltip
+                    this.addTooltipForCard(card);
+                }
+                // Provide links to get access to that window and close it
+                dojo.connect($('forecast_text_' + this.player_id), 'onclick', this, 'click_display_forecast_window');
+                dojo.connect($('forecast_close_window'), 'onclick', this, 'click_close_forecast_window');
+            }
             
             // My score: create an extra zone to show the versos of the cards at will in a windows
             if (!this.isSpectator) {
                 this.my_score_verso_window.attr("content", "<div id='my_score_verso'></div><a id='score_close_window' class='bgabutton bgabutton_blue'>Close</a>");
                 this.zone.my_score_verso = this.createZone('my_score_verso', this.player_id, null, null, null, grouped_by_age_type_and_is_relic=true);
                 this.setPlacementRules(this.zone.my_score_verso, left_to_right=true);
-                for(var i=0; i<gamedatas.my_score.length; i++) {
+                for (var i = 0; i < gamedatas.my_score.length; i++) {
                     var card = gamedatas.my_score[i];
                     this.createAndAddToZone(this.zone.my_score_verso, card.position, card.age, card.type, card.is_relic, card.id, dojo.body(), card);
                     // Add tooltip
                     this.addTooltipForCard(card);
                 }
                 // Provide links to get access to that window and close it
-                dojo.connect($('score_text_' + this.player_id), 'onclick', this, 'clic_display_score_window');
-                dojo.connect($('score_close_window'), 'onclick', this, 'clic_close_score_window');
+                dojo.connect($('score_text_' + this.player_id), 'onclick', this, 'click_display_score_window');
+                dojo.connect($('score_close_window'), 'onclick', this, 'click_close_score_window');
             }
             
             // PLAYERS' ACHIEVEMENTS
@@ -570,6 +593,8 @@ function (dojo, declare) {
             }
             
             if (!this.isSpectator) {
+                dojo.query('#progress_' + this.player_id + ' .forecast_container > p, #progress_' + this.player_id + ' .achievement_container > p').addClass('two_lines');
+                dojo.query('#progress_' + this.player_id + ' .forecast_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(click to look at the cards)') + '</span>';
                 dojo.query('#progress_' + this.player_id + ' .score_container > p, #progress_' + this.player_id + ' .achievement_container > p').addClass('two_lines');
                 dojo.query('#progress_' + this.player_id + ' .score_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(click to look at the cards)') + '</span>';
                 dojo.query('#progress_' + this.player_id + ' .achievement_container > p')[0].innerHTML += '<br /><span class="minor_information">' + _('(${n} needed to win)').replace('${n}', gamedatas.number_of_achievements_needed_to_win) + '</span>';
@@ -2081,13 +2106,15 @@ function (dojo, declare) {
                 new_location = location;
             }
 
-            var HTML_class = this.HTML_class[new_location]
-            var card_dimensions = this.card_dimensions[HTML_class]
+            var HTML_class = this.HTML_class[new_location];
+            var card_dimensions = this.card_dimensions[HTML_class];
             
             // Width of the zone
             var zone_width;
             if(new_location == 'board') {
                 zone_width = card_dimensions.width; // Will change dynamically if splayed left or right
+            } else if (new_location == 'forecast') {
+                zone_width = dojo.position('forecast_container_' + owner).w;
             } else if (new_location == 'score') {
                 zone_width = dojo.position('score_container_' + owner).w;
             } else if (new_location != 'relics' && new_location != 'achievements' && new_location != 'special_achievements') {
@@ -2097,7 +2124,7 @@ function (dojo, declare) {
             }
             
             // Id of the container
-            if (location == "my_score_verso") {
+            if (location == "my_score_verso" || location == "my_forecast_verso") {
                 var div_id = location;
             } else {
                 var div_id = location + owner_string + type_string + age_string + color_string;
@@ -3169,12 +3196,20 @@ function (dojo, declare) {
             
             zone.updateDisplay();
         },
+
+        click_display_forecast_window : function() {
+            this.my_forecast_verso_window.show();
+        },
         
-        clic_display_score_window : function() {
+        click_close_forecast_window : function() {
+            this.my_forecast_verso_window.hide();
+        },
+        
+        click_display_score_window : function() {
             this.my_score_verso_window.show();
         },
         
-        clic_close_score_window : function() {
+        click_close_score_window : function() {
             this.my_score_verso_window.hide();
         },
         

--- a/innovation.scss
+++ b/innovation.scss
@@ -171,7 +171,7 @@
     vertical-align: top;
     display: inline-block;
     position: relative;
-    >p {
+    p {
         font-style: italic;
         font-size: 0.8em;
         position: absolute;
@@ -189,7 +189,7 @@
     vertical-align: top;
     display: inline-block;
     position: relative;
-    >p {
+    p {
         font-style: italic;
         font-size: 0.8em;
         position: absolute;

--- a/innovation.scss
+++ b/innovation.scss
@@ -50,7 +50,7 @@
     height: 30px;
 }
 .debug_button {
-    width: 100px;
+    width: 150px;
 }
 .card_name {
     font-weight: bold;
@@ -177,10 +177,10 @@
         position: absolute;
         top: 0px;
         margin: 0px;
-        right: 3px;
+        left: 3px;
         height: 16px;
         overflow-y: hidden;
-        text-align: right;
+        text-align: left;
     }
 }
 
@@ -618,6 +618,7 @@
 .two_lines {
     top: -16px !important;
     height: 32px !important;
+    padding-right: 3px; // Necessary because the text is in italics and is otherwise cut off slightly
 }
 .sep {
     display: inline-block;

--- a/innovation.scss
+++ b/innovation.scss
@@ -166,7 +166,7 @@
     display: flex;
     margin-top: 30px;
 }
-.score_container {
+.forecast_container {
     flex-grow: 1;
     vertical-align: top;
     display: inline-block;
@@ -184,7 +184,23 @@
     }
 }
 
-
+.score_container {
+    flex-grow: 1;
+    vertical-align: top;
+    display: inline-block;
+    position: relative;
+    >p {
+        font-style: italic;
+        font-size: 0.8em;
+        position: absolute;
+        top: 0px;
+        margin: 0px;
+        right: 3px;
+        height: 16px;
+        overflow-y: hidden;
+        text-align: right;
+    }
+}
 
 .achievement_container {
     vertical-align: top;
@@ -209,6 +225,12 @@
         overflow-y: hidden;
     }
 }
+.forecast {
+    display: inline-block;
+    margin-top: 18px;
+    display: inline-block;
+    height: 49px;
+}
 .score {
     display: inline-block;
     margin-top: 18px;
@@ -220,6 +242,13 @@
     margin-top: 18px;
     display: inline-block;
     height: 49px;
+}
+.forecast_show_window {
+    text-decoration: underline;
+    font-weight: bold;
+    &:hover {
+        cursor: pointer;
+    }
 }
 .score_show_window {
     text-decoration: underline;

--- a/innovation.view.php
+++ b/innovation.view.php
@@ -92,10 +92,12 @@
                                                     "R" => $rgb[0],
                                                     "G" => $rgb[1],
                                                     "B" => $rgb[2],
-                                                    "OPT_CLASS" => " class='score_show_window'",
+                                                    "OPT_FORECAST_CLASS" => " class='forecast_show_window'",
+                                                    "OPT_SCORE_CLASS" => " class='score_show_window'",
                                                     "HAND" => self::_("Hand"),
                                                     "DISPLAY" => self::_("Artifact on Display"),
-                                                    "SCORE_PILE" => self::_("Score pile"), 
+                                                    "FORECAST_PILE" => self::_("Forecast pile"),
+                                                    "SCORE_PILE" => self::_("Score pile"),
                                                     "ACHIEVEMENTS" => self::_("Achievements")
                                                     ) );
             // Opponents
@@ -145,7 +147,8 @@
                                         "R" => $rgb[0],
                                         "G" => $rgb[1],
                                         "B" => $rgb[2],
-                                        "OPT_CLASS" => "",
+                                        "OPT_FORECAST_CLASS" => "",
+                                        "OPT_SCORE_CLASS" => "",
                                         "HAND" => self::_("Hand"),
                                         "DISPLAY" => self::_("Artifact on Display"),
                                         "SCORE_PILE" => self::_("Score pile"),

--- a/innovation_innovation.tpl
+++ b/innovation_innovation.tpl
@@ -39,8 +39,12 @@
                 </div>
             </div>
             <div id="progress_{PLAYER_ID}" class="progress">
+                <div id="forecast_container_{PLAYER_ID}" class="forecast_container">
+                    <p id="forecast_text_{PLAYER_ID}"{OPT_FORECAST_CLASS}>{FORECAST_PILE}</p>
+                    <div id="forecast_{PLAYER_ID}" class="forecast"></div>
+                </div>
                 <div id="score_container_{PLAYER_ID}" class="score_container">
-                    <p id="score_text_{PLAYER_ID}"{OPT_CLASS}>{SCORE_PILE}</p>
+                    <p id="score_text_{PLAYER_ID}"{OPT_SCORE_CLASS}>{SCORE_PILE}</p>
                     <div id="score_{PLAYER_ID}" class="score"></div>
                 </div>
                 <div id="reference_card_{PLAYER_ID}" class="reference_card S"></div>


### PR DESCRIPTION
NOTE: I didn't spend any time working out sensible calculations for the division of the forecast and score zone. Ideally, we'd leave one card's width of space between the two area so that it's never unclear whether a card is in the forecast or the score pile. I'll leave this to @lordmcfuzz to address sometime in the future, but it's not urgent now.

<img width="660" alt="Screen Shot 2022-04-29 at 12 44 36 AM" src="https://user-images.githubusercontent.com/7231485/165864961-4ece630f-8e67-4a8b-b33d-169ca73ef642.png">
<img width="771" alt="Screen Shot 2022-04-29 at 12 44 42 AM" src="https://user-images.githubusercontent.com/7231485/165864965-a8040e85-15a9-4033-96cf-c108487e4075.png">
<img width="969" alt="Screen Shot 2022-04-29 at 12 44 48 AM" src="https://user-images.githubusercontent.com/7231485/165864970-82315ea5-fcbe-4d9a-bc16-679b4d9ff2a0.png">
<img width="250" alt="Screen Shot 2022-04-29 at 12 45 48 AM" src="https://user-images.githubusercontent.com/7231485/165865034-c5794ee5-6373-4cd9-8df3-a8472ecffcf6.png">
