### PR TITLE
Remove padding from age squares

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -1031,24 +1031,22 @@
 .square.basic.icon_action {
   background-position: -48px 0px;
 }
-.square.N {
-  width: 14px;
-  height: 14px;
-}
 .square.N.icon_1, .square.N.icon_2, .square.N.icon_3, .square.N.icon_4, .square.N.icon_5, .square.N.icon_6 {
   background-image: url("img/resource_icons.jpg");
   background-size: 92px auto;
   background-position-y: -77px;
+  width: 14px;
+  height: 14px;
 }
 .square.N.age {
   background-color: black;
   border: 1px solid white;
   color: white;
   text-align: center;
-  padding-right: 1px;
-  padding-left: 1px;
   font-size: 11px;
-  line-height: 16px;
+  line-height: 12px;
+  width: 13px;
+  height: 12px;
 }
 .square.N.icon_1 {
   background-position-x: 0px;
@@ -1109,8 +1107,6 @@
   border: 1px solid white;
   color: white;
   text-align: center;
-  padding-right: 1px;
-  padding-left: 1px;
   width: 8px;
   height: 8px;
   font-size: 6px;
@@ -1148,8 +1144,6 @@
   border: 1px solid white;
   color: white;
   text-align: center;
-  padding-right: 1px;
-  padding-left: 1px;
   font-size: inherit;
   line-height: 19px;
 }
@@ -1176,8 +1170,6 @@
   border: 1px solid white;
   color: white;
   text-align: center;
-  padding-right: 1px;
-  padding-left: 1px;
   width: 14px;
   height: 14px;
   font-size: 12px;

--- a/innovation.scss
+++ b/innovation.scss
@@ -989,17 +989,19 @@
         }
     }
     &.N {
-        width: 14px;
-        height: 14px;
         &.icon_1,&.icon_2,&.icon_3,&.icon_4,&.icon_5,&.icon_6 {
             @include m.icon-background;
             background-size: 92px auto;
             background-position-y: -77px;
+            width: 14px;
+            height: 14px;
         }
         &.age {
 			@include m.square-age;
 			font-size: 11px;
-			line-height: 16px;
+			line-height: 12px;
+			width: 13px;
+			height: 12px;
 		}
         @include m.generate-icon-x-position(1, 6, 0, 15.5px);
     }

--- a/misc/_mixins.scss
+++ b/misc/_mixins.scss
@@ -42,8 +42,6 @@
 	border: 1px solid white;
 	color: white;
 	text-align: center;
-	padding-right: 1px;
-	padding-left: 1px;
 }
 
 @mixin icon-background {


### PR DESCRIPTION
I removed the padding on each side of the age squares. This padding was originally only for the age 10 & 11 icons, I believe, but now we use the same CSS for all ages.

I made more substantial changes to the age squares in the game log (.N class).

Before: 
<img width="193" alt="Screen Shot 2022-05-16 at 10 14 40 AM" src="https://user-images.githubusercontent.com/7231485/168615288-f09fe806-2f53-4a10-b125-c485916f4dfb.png">

After:
<img width="214" alt="Screen Shot 2022-05-16 at 10 18 32 AM" src="https://user-images.githubusercontent.com/7231485/168615344-df4ae0d7-651e-4fcc-929b-db3e6a4f8086.png">
