### PR TITLE
Improve layout of age squares within dogma text on .M cards (#245)

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -1113,6 +1113,7 @@
   line-height: 6px;
   margin-top: -1px;
   margin-bottom: -1px;
+  border-width: 0.5px;
 }
 .font_size_1 .square.M.age, .font_size_2 .square.M.age, .font_size_3 .square.M.age, .font_size_4 .square.M.age {
   width: 4px;
@@ -1121,14 +1122,12 @@
   line-height: 4px;
   margin-top: 0px;
   margin-bottom: 0px;
-  border: 0.5px solid white;
 }
 .font_size_5 .square.M.age {
   width: 5px;
   height: 5px;
   font-size: 4px;
   line-height: 5px;
-  border: 0.5px solid white;
 }
 .square.M.icon_1 {
   background-position-x: 0px;

--- a/innovation.css
+++ b/innovation.css
@@ -1107,10 +1107,28 @@
   border: 1px solid white;
   color: white;
   text-align: center;
-  width: 8px;
-  height: 8px;
-  font-size: 6px;
-  line-height: 8px;
+  width: 6px;
+  height: 6px;
+  font-size: 5px;
+  line-height: 6px;
+  margin-top: -1px;
+  margin-bottom: -1px;
+}
+.font_size_1 .square.M.age, .font_size_2 .square.M.age, .font_size_3 .square.M.age, .font_size_4 .square.M.age {
+  width: 4px;
+  height: 4px;
+  font-size: 3px;
+  line-height: 4px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  border: 0.5px solid white;
+}
+.font_size_5 .square.M.age {
+  width: 5px;
+  height: 5px;
+  font-size: 4px;
+  line-height: 5px;
+  border: 0.5px solid white;
 }
 .square.M.icon_1 {
   background-position-x: 0px;

--- a/innovation.scss
+++ b/innovation.scss
@@ -1031,6 +1031,7 @@
 			line-height: 6px;
 			margin-top: -1px;
 			margin-bottom: -1px;
+			border-width: 0.5px;
 		}
 		.font_size_1 &.age, .font_size_2 &.age, .font_size_3 &.age, .font_size_4 &.age {
 			width: 4px;
@@ -1039,14 +1040,12 @@
 			line-height: 4px;
 			margin-top: 0px;
 			margin-bottom: 0px;
-			border: 0.5px solid white;
 		}
 		.font_size_5 &.age {
 			width: 5px;
 			height: 5px;
 			font-size: 4px;
 			line-height: 5px;
-			border: 0.5px solid white;
 		}
         @include m.generate-icon-x-position(1, 6, 0, 8.33px);
     }

--- a/innovation.scss
+++ b/innovation.scss
@@ -1025,10 +1025,28 @@
         }
 		&.age {
 			@include m.square-age;
-			width: 8px;
-            height: 8px;
-			font-size: 6px;
-			line-height: 8px;
+			width: 6px;
+			height: 6px;
+			font-size: 5px;
+			line-height: 6px;
+			margin-top: -1px;
+			margin-bottom: -1px;
+		}
+		.font_size_1 &.age, .font_size_2 &.age, .font_size_3 &.age, .font_size_4 &.age {
+			width: 4px;
+			height: 4px;
+			font-size: 3px;
+			line-height: 4px;
+			margin-top: 0px;
+			margin-bottom: 0px;
+			border: 0.5px solid white;
+		}
+		.font_size_5 &.age {
+			width: 5px;
+			height: 5px;
+			font-size: 4px;
+			line-height: 5px;
+			border: 0.5px solid white;
 		}
         @include m.generate-icon-x-position(1, 6, 0, 8.33px);
     }


### PR DESCRIPTION
Before:
<img width="190" alt="Screen Shot 2022-05-17 at 10 42 19 AM" src="https://user-images.githubusercontent.com/7231485/168852471-e4420adb-32aa-43c0-b09f-bd01a8c3fe08.png">

After (font sizes 4-7):
<img width="189" alt="Screen Shot 2022-05-17 at 11 44 45 AM" src="https://user-images.githubusercontent.com/7231485/168853349-1cd0f4e0-5ab1-4736-804b-16176f304262.png">
<img width="191" alt="Screen Shot 2022-05-17 at 11 44 55 AM" src="https://user-images.githubusercontent.com/7231485/168853354-be1bad76-5b45-45db-8da0-1521eecd5339.png">
<img width="189" alt="Screen Shot 2022-05-17 at 11 45 05 AM" src="https://user-images.githubusercontent.com/7231485/168853357-0ce5afbe-d0fd-45e2-aa15-7849f999dac5.png">
<img width="193" alt="Screen Shot 2022-05-17 at 11 45 14 AM" src="https://user-images.githubusercontent.com/7231485/168853360-2706cc7b-f375-4883-bcec-b8d23b55be94.png">

