### PR TITLE
Make expansion decks transparent if their base deck is empty (#451)

### DIFF
--- a/innovation.js
+++ b/innovation.js
@@ -2174,6 +2174,7 @@ function (dojo, declare) {
                 this.createAndAddToZone(zone_to, card.position_to, card.age, card.type, card.is_relic, id_to, this.getCardHTMLId(id_from, card.age, card.type, card.is_relic, zone_from.HTML_class), card);
                 this.removeFromZone(zone_from, id_from, true, card.age, card.type, card.is_relic);
             }
+            this.updateDeckOpacities();
         },
         
         addToZone: function (zone, id, position, age, type, is_relic) {
@@ -2246,6 +2247,8 @@ function (dojo, declare) {
                     dojo.style(zone.counter.span, 'visibility', zone.counter.getValue() == 0 ? 'hidden' : 'visible');
                 }
             }
+
+            this.updateDeckOpacities();
         },
         
         removeFromZone: function (zone, id, destroy, age, type, is_relic) {
@@ -2294,6 +2297,8 @@ function (dojo, declare) {
                     dojo.style(zone.counter.span, 'visibility', zone.counter.getValue() == 0 ? 'hidden' : 'visible');
                 }
             }
+
+            this.updateDeckOpacities();
         },
         
         shrinkZoneForNoneOrUpSplay : function(zone) {
@@ -2348,6 +2353,19 @@ function (dojo, declare) {
                 var y = parseInt(i / 3) * (h + 5);
                 
                 return {'x':x, 'y':y, 'w':w, 'h':h};
+            }
+        },
+
+        // Reduce opacity of expansion decks if the accompanying base deck is empty.
+        updateDeckOpacities : function() {
+            for (var a = 1; a <= 10; a++) {
+                var opacity = document.getElementById(`deck_0_${a}`).childElementCount > 0 ? 1.0 : 0.35;
+                for (var t = 1; t <= 4; t++) {
+                    var deck = document.getElementById(`deck_${t}_${a}`);
+                    if (deck != null) {
+                        deck.parentElement.style.opacity = opacity;
+                    }
+                }
             }
         },
         


### PR DESCRIPTION
What do you think of this feature? It should also make it more obvious which artifact will go on display since it's easier to tell which ages are skipped.

<img width="240" alt="Screen Shot 2022-05-23 at 12 59 51 PM" src="https://user-images.githubusercontent.com/7231485/169870994-a949a629-dfe5-4982-a3fb-d73e32ed4ab3.png">
