### PR TITLE
Fix bug preventing tooltips from appearing in game log after reload (#441)

### DIFF
--- a/innovation.js
+++ b/innovation.js
@@ -729,7 +729,7 @@ function (dojo, declare) {
                 var card_id = this.cards[i].id;
                 // For some reason, after a page refresh, each entry in the game log is located in two diffferent
                 // spots on the page, meaning that each span holding a card name no longer has a unique ID (since
-                // it appears exactly twice), BGA's framework to add a tooltip requires that it has a unique ID.
+                // it appears exactly twice), and BGA's framework to add a tooltip requires that it has a unique ID.
                 // The workaround here is to first remove the extra IDs, before trying to add the tooltips.
                 dojo.query("#chatbar .card_id_" + card_id).removeAttr('id');
                 var elements = dojo.query(".card_id_" + card_id);

--- a/innovation.js
+++ b/innovation.js
@@ -727,6 +727,11 @@ function (dojo, declare) {
             // Add card tooltips to existing game log messages
             for (var i = 0; i < this.cards.length; i++) {
                 var card_id = this.cards[i].id;
+                // For some reason, after a page refresh, each entry in the game log is located in two diffferent,
+                // spots on the page, meaning that each span holding a card name no longer has a unique ID (since
+                // it appears exactly twice), BGA's framework to add a tooltip requires that it has a unique ID.
+                // The workaround here is to first remove the extra IDs, before trying to add the tooltips.
+                dojo.query("#chatbar .card_id_" + card_id).removeAttr('id');
                 var elements = dojo.query(".card_id_" + card_id);
                 if (elements.length > 0 && this.canShowCardTooltip(card_id)) {
                     this.addCustomTooltipToClass("card_id_" + card_id, this.getTooltipForCard(card_id), "");

--- a/innovation.js
+++ b/innovation.js
@@ -727,7 +727,7 @@ function (dojo, declare) {
             // Add card tooltips to existing game log messages
             for (var i = 0; i < this.cards.length; i++) {
                 var card_id = this.cards[i].id;
-                // For some reason, after a page refresh, each entry in the game log is located in two diffferent,
+                // For some reason, after a page refresh, each entry in the game log is located in two diffferent
                 // spots on the page, meaning that each span holding a card name no longer has a unique ID (since
                 // it appears exactly twice), BGA's framework to add a tooltip requires that it has a unique ID.
                 // The workaround here is to first remove the extra IDs, before trying to add the tooltips.


### PR DESCRIPTION
This fixes the bug which prevented tooltips from being re-added to the card names in the game log after refreshing the page.