### PR TITLE
Fix bug in Delft Pocket Telescope causing hidden info to be revealed

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -14256,7 +14256,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'revealed',
 
                 'card_id_1' => $card_id_1,
-                'card_id_2' => $card_id_2
+                'card_id_2' => $card_id_2,
+
+                'enable_autoselection' => false, // Automating this always reveals hidden info
             );
             break;
 


### PR DESCRIPTION
One of Delft Pocket Telescope's interactions needs to have automation disabled, otherwise it will reveal hidden information. Opponents shouldn't know that they only have one choosable card when revealing a card from their hand.