### PR TITLE
Add custom warning to Tools

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -7982,6 +7982,8 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
             'splay_direction' => $splay_direction,
             'splay_direction_in_clear' => $splay_direction_in_clear,
             'color_pile' => $splay_direction === null && $location_from == 'pile' ? self::getGameStateValueAsArray('color_array')[0] : null,
+            'card_interaction' => $code,
+            'num_cards_already_chosen' => $n,
             
             // Private info
             '_private' => array(

--- a/innovation.js
+++ b/innovation.js
@@ -936,7 +936,7 @@ function (dojo, declare) {
                             var age_3s_in_hand = dojo.query("#hand_" + this.player_id + " > .card.age_3");
                             this.off(age_3s_in_hand, 'onclick', 'action_clicForChoose');
                             this.on(age_3s_in_hand, 'onclick', 'action_clickForChooseFront');
-                            var warning = _("Are you sure you want to return a ${age_3} as part of the first non-demand effect? This won't allow you to draw three cards.").replace("${age_3}", this.square('N', 'age', 3));
+                            var warning = _("Are you sure you want to return a ${age_3}? This won't allow you to draw three cards.").replace("${age_3}", this.square('N', 'age', 3));
                             age_3s_in_hand.forEach(function(card) {
                                 dojo.attr(card, 'warning', warning);
                             });

--- a/innovation.js
+++ b/innovation.js
@@ -930,6 +930,17 @@ function (dojo, declare) {
                             selectable_rectos.addClass("clickable");
                             this.on(selectable_rectos, 'onclick', 'action_clicForChooseRecto');
                         }
+                        // Add special warning to Tools to prevent the player from accidentally returning a 3 in the first
+                        // part of the interaction in an attempt to draw 3 cards.
+                        if (args.args.card_interaction == "1N1A" && parseInt(args.args.num_cards_already_chosen) == 0) {
+                            var age_3s_in_hand = dojo.query("#hand_" + this.player_id + " > .card.age_3");
+                            this.off(age_3s_in_hand, 'onclick', 'action_clicForChoose');
+                            this.on(age_3s_in_hand, 'onclick', 'action_clickForChooseFront');
+                            var warning = _("Are you sure you want to return a ${age_3} as part of the first non-demand effect? It's more common for players to return it as part of the second non-demand effect.").replace("${age_3}", this.square('N', 'age', 3));
+                            age_3s_in_hand.forEach(function(card) {
+                                dojo.attr(card, 'warning', warning);
+                            });
+                        }
                     }
                     else if (args.args.special_type_of_choice == 6 /* rearrange */) {
                         this.off(dojo.query('#change_display_mode_button'), 'onclick');
@@ -2872,18 +2883,47 @@ function (dojo, declare) {
                 function(is_error) { if (is_error) this.resurrectClickEvents(true); }
             );
         },
-        
-        action_clicForChoose : function(event) {
-            if(!this.checkAction('choose')){
-                return;
-            }
-            if (this.color_pile !== null) { // Special code where a stack needed to be selected
-                var zone = this.zone.board[this.player_id][this.color_pile];
-                this.setSplayMode(zone, zone.splay_direction, force_full_visible=false);
-            }
+
+        action_clickForChooseFront : function(event) {
+            this.stopActionTimer();
             this.deactivateClickEvents();
             
             var HTML_id = this.getCardHTMLIdFromEvent(event);
+            var warning = dojo.attr(HTML_id, 'warning');
+
+            $('pagemaintitletext').innerHTML = warning;
+
+            // Add cancel button
+            this.addActionButton("choose_front_cancel_button", _("Cancel"), "action_cancelChooseFront");
+            dojo.removeClass("choose_front_cancel_button", 'bgabutton_blue');
+            dojo.addClass("choose_front_cancel_button", 'bgabutton_red');
+
+            // Add confirm button
+            this.addActionButton("choose_front_confirm_button", _("Confirm"), "action_manuallyConfirmChooseFront");
+            $("choose_front_confirm_button").innerHTML = _("Confirm");
+            dojo.attr('choose_front_confirm_button', 'html_id', HTML_id);
+
+            // TODO(LATER): If the card doesn't have a warning, add a confirmation button with a countdown timer.
+        },
+
+        action_cancelChooseFront : function(event) {
+            this.stopActionTimer();
+            this.resurrectClickEvents(true);
+            dojo.destroy("choose_front_cancel_button");
+            dojo.destroy("choose_front_confirm_button");
+        },
+
+        action_manuallyConfirmChooseFront : function(event) {
+            this.stopActionTimer();
+            var HTML_id = dojo.attr('choose_front_confirm_button', 'html_id');
+            this.action_confirmChooseFront(HTML_id);
+        },
+
+        action_confirmChooseFront : function(HTML_id) {
+            if(!this.checkAction('choose')){
+                return;
+            }
+            
             var card_id = this.getCardIdFromHTMLId(HTML_id);
             
             var self = this;
@@ -2894,6 +2934,18 @@ function (dojo, declare) {
                             },
                              this, function(result){}, function(is_error){if(is_error)self.resurrectClickEvents(true)}
                         );
+        },
+        
+        // TODO(LATER): Remove this once we have a personal preference for confirming card choices.
+        action_clicForChoose : function(event) {
+            if (this.color_pile !== null) { // Special code where a stack needed to be selected
+                var zone = this.zone.board[this.player_id][this.color_pile];
+                this.setSplayMode(zone, zone.splay_direction, force_full_visible=false);
+            }
+            this.deactivateClickEvents();
+            
+            var HTML_id = this.getCardHTMLIdFromEvent(event);
+            this.action_confirmChooseFront(HTML_id);
         },
         
         action_clicForChooseRecto : function(event) {

--- a/innovation.js
+++ b/innovation.js
@@ -936,7 +936,7 @@ function (dojo, declare) {
                             var age_3s_in_hand = dojo.query("#hand_" + this.player_id + " > .card.age_3");
                             this.off(age_3s_in_hand, 'onclick', 'action_clicForChoose');
                             this.on(age_3s_in_hand, 'onclick', 'action_clickForChooseFront');
-                            var warning = _("Are you sure you want to return a ${age_3} as part of the first non-demand effect? It's more common for players to return it as part of the second non-demand effect.").replace("${age_3}", this.square('N', 'age', 3));
+                            var warning = _("Are you sure you want to return a ${age_3} as part of the first non-demand effect? This won't allow you to draw three cards.").replace("${age_3}", this.square('N', 'age', 3));
                             age_3s_in_hand.forEach(function(card) {
                                 dojo.attr(card, 'warning', warning);
                             });


### PR DESCRIPTION
One of the biggest requests from players is to improve the UX with Tools (https://boardgamearena.com/bug?id=18164). this is my proposal for addressing it.
<img width="961" alt="Screen Shot 2022-09-03 at 11 51 27 AM" src="https://user-images.githubusercontent.com/7231485/188278898-0c8e4708-4c10-47b5-9c54-03850177acbc.png">

Please note that I structured the JS code in a way that it will make it easy to add confirmation buttons on a timer like we do for meld/dogma actions. I can easily see us wanting to give players an option to confirm card selections as well.