### PR TITLE
Remove 'immediately' from Echo special achievements

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -3185,9 +3185,9 @@ class Innovation extends Table
     
     /** Checks if the player meets the conditions to get a special achievement. Do the transfer if he does. **/
     function checkForSpecialAchievementsForPlayer($player_id, $onlyImmediateAchievements) {
-        // TODO(CITIES,FIGURES): Update this once there are other special achievements to test for.
+        // TODO(FIGURES): Update this once there are other special achievements to test for.
         $achievements_to_test = $onlyImmediateAchievements ? array(106) : array(105, 106, 107, 108, 109);
-        if (self::getGameStateValue('echoes_mode') > 1) {
+        if (self::getGameStateValue('echoes_mode') > 1 && !$onlyImmediateAchievements) {
             $achievements_to_test = array_merge($achievements_to_test, [435, 436, 437, 438, 439]);
         }
         $end_of_game = false;
@@ -7233,21 +7233,21 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                         break;
                     case 11: // Left Arrow: Splay the city's color left
                         if (self::getCurrentSplayDirection($player_id, $card['color']) == 1) {
-                            self::claimSpecialAchievement($player_id, 325);
+                            self::claimSpecialAchievement($player_id, 325); // Legend
                         } else {
                             self::splayLeft($player_id, $player_id, $card['color']);
                         }
                         break;
                     case 12: // Right Arrow: Splay the city's color right
                         if ( self::getCurrentSplayDirection($player_id, $card['color']) == 2) {
-                            self::claimSpecialAchievement($player_id, 326);
+                            self::claimSpecialAchievement($player_id, 326); // Repute
                         } else {
                             self::splayRight($player_id, $player_id, $card['color']);
                         }
                         break;
                     case 13: // Up Arrow: Splay the city's color up
                         if ( self::getCurrentSplayDirection($player_id, $card['color']) == 3) {
-                            self::claimSpecialAchievement($player_id, 327);
+                            self::claimSpecialAchievement($player_id, 327); // Fame
                         } else {
                             self::splayUp($player_id, $player_id, $card['color']);
                         }

--- a/material.inc.php
+++ b/material.inc.php
@@ -1754,23 +1754,23 @@ $this->textual_card_infos = array(
 /* Echoes - Special achievements */
 
 435 => array('name' => clienttranslate('Wealth'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have eight or more bonuses visible on your board.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have eight or more bonuses visible on your board.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_5} Palampore.')),
 
 436 => array('name' => clienttranslate('Destiny'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have seven or more cards in your forecast.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have seven or more cards in your forecast.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_4} Barometer.')),
 
 437 => array('name' => clienttranslate('Heritage'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have eight or more ${icon_0} visible in one color.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have eight or more ${icon_0} visible in one color.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_6} Loom.')),
 
 438 => array('name' => clienttranslate('History'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have a color with four or more visible echo effects.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have a color with four or more visible echo effects.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_7} Photography.')),
 
 439 => array('name' => clienttranslate('Supremacy'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have three icons or more of the same icon type visible in each of four different colors. (Each color has to have the same icon as the other colors.)'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have three icons or more of the same icon type visible in each of four different colors. (Each color has to have the same icon as the other colors.)'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_3} Novel.')),
 
 );


### PR DESCRIPTION
This makes things consistent with the changes we made regarding special achievement timing in the base and artifact special achievements.