### PR TITLE
Remove transparency from current effect highlighting (#614)

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -967,10 +967,10 @@
   box-shadow: 0px 0px 6px 2px #fff;
 }
 .current_effect.light {
-  background-color: rgba(255, 255, 255, 0.8) !important;
+  background-color: white !important;
 }
 .current_effect.dark {
-  background-color: rgba(0, 0, 0, 0.8) !important;
+  background-color: black !important;
 }
 
 .clickable {

--- a/innovation.scss
+++ b/innovation.scss
@@ -926,10 +926,10 @@
 .current_effect {
     box-shadow: 0px 0px 6px 2px #fff;
     &.light {
-        background-color: rgb(255 255 255 / 80%) !important;
+        background-color: rgb(255 255 255) !important;
     }
     &.dark {
-        background-color: rgb(0 0 0 / 80%) !important;
+        background-color: rgb(0 0 0) !important;
     }
 }
 .clickable {


### PR DESCRIPTION
Before:
<img width="198" alt="Screen Shot 2022-09-27 at 4 57 59 PM" src="https://user-images.githubusercontent.com/7231485/192634372-7a74b0a0-4ff9-4d1e-ae84-8c94aa5b66fe.png">
<img width="197" alt="Screen Shot 2022-09-27 at 4 58 13 PM" src="https://user-images.githubusercontent.com/7231485/192634378-a9a00f3c-5348-49c4-ac50-5c26d641778f.png">

After:
<img width="200" alt="Screen Shot 2022-09-27 at 4 57 14 PM" src="https://user-images.githubusercontent.com/7231485/192634411-373a7852-1cc2-4a88-ad1e-66be7c8dc4ce.png">
<img width="202" alt="Screen Shot 2022-09-27 at 4 57 10 PM" src="https://user-images.githubusercontent.com/7231485/192634407-8bc246bd-563b-49e4-8e73-0e60a88517c3.png">


