### PR TITLE
Example of using bga-wb and inversion of control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on: [push, pull_request]
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: false
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: innovation_test
+        ports:
+          - 3306/tcp
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v2
@@ -14,5 +24,14 @@ jobs:
           php-version: '7.4'
       - name: Install dependencies
         run: composer install -n --prefer-dist
+      - name: Create bgaproject.yml
+        run: cp bgaproject.ci.yml bgaproject.yml
       - name: Run Tests
         run: env CI=1 ./vendor/bin/phpunit --coverage-text
+        env:
+          CI: 1
+          TEST_DB_NAME: innovation_test
+          TEST_DB_USER: root
+          TEST_DB_PASS: password
+          TEST_DB_HOST: 0.0.0.0
+          TEST_DB_PORT: ${{ job.services.mysql.ports[3306] }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ package-lock.json
 innovation.css.map
 vendor/
 .phpunit.result.cache
+
+/backup
+/build
+/dist
+/bgaproject.yml
+!/bgaproject.yml.dist

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ In order to test changes to the game, you need to be able to copy the code out o
 
 Once the project is checked out, run `composer install` to pull the dependencies (mainly for unit testing).
 
+Finally, copy `bgaproject.dist.yml` to `bgaproject.yml`, and edit the values for your local database information. (You can leave the sftp stanza blank.) 
+
 #### Setting up your branch
 In order to submit changes to this repository you will need to eventually submit a pull request with your changes. This means you need to have your own local branch. Before running the following commands, make sure you are on the branch of this repository that you want to diverge from (e.g. `main-dev`) and that you have called `git pull` so that you have the latest changes.
 ```

--- a/bgaproject.ci.yml
+++ b/bgaproject.ci.yml
@@ -1,0 +1,15 @@
+useComposer: false
+testDb:
+    name: innovation_test
+    namePrefix: innovation_test_
+    user: root
+    pass: password
+    externallyManaged: true
+
+sftp:
+    host: ""
+    user: ""
+    pass: ""
+
+linterPhpBin: php
+extraSrc: []

--- a/bgaproject.dist.yml
+++ b/bgaproject.dist.yml
@@ -1,0 +1,13 @@
+useComposer: false
+testDb:
+    namePrefix: innovation_test_
+    user: root
+    pass: ""
+
+sftp:
+    host: ""
+    user: ""
+    pass: ""
+
+linterPhpBin: php
+extraSrc: []

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "type": "library",
   "description": "BoardGameArena implementation of Innovation",
-  "minimum-stability": "stable",
+  "minimum-stability": "dev",
   "autoload": {
     "psr-4": {
     },
@@ -17,8 +17,14 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",
-    "dholmes/bga-workbench": "^0.2.1"
+    "splittingred/bga-workbench": "dev-master"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/splittingred/bga-workbench.git"
+    }
+  ],
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "443194b76bdc7f718ea47917619f1f48",
+    "content-hash": "8019939182e6cd760dd8cdadc2750918",
     "packages": [],
     "packages-dev": [
         {
@@ -59,10 +59,6 @@
                 "class",
                 "preload"
             ],
-            "support": {
-                "issues": "https://github.com/ClassPreloader/ClassPreloader/issues",
-                "source": "https://github.com/ClassPreloader/ClassPreloader/tree/3.2"
-            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/classpreloader/classpreloader",
@@ -70,74 +66,6 @@
                 }
             ],
             "time": "2020-04-12T22:01:25+00:00"
-        },
-        {
-            "name": "dholmes/bga-workbench",
-            "version": "0.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/danielholmes/bga-workbench.git",
-                "reference": "46e4c5a7234bda0d7e985e020153a3f370a27cd2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/danielholmes/bga-workbench/zipball/46e4c5a7234bda0d7e985e020153a3f370a27cd2",
-                "reference": "46e4c5a7234bda0d7e985e020153a3f370a27cd2",
-                "shasum": ""
-            },
-            "require": {
-                "classpreloader/classpreloader": "^3.1.0",
-                "doctrine/dbal": "^2.5.12",
-                "ext-mysqli": "*",
-                "ext-pdo_mysql": "*",
-                "fzaninotto/faker": "^1.7.1",
-                "hamcrest/hamcrest-php": "^2.0.0",
-                "illuminate/support": ">=4.0 < 6.0.0",
-                "jasonlewis/resource-watcher": "1.2.0",
-                "lstrojny/functional-php": ">=1.6.0 <1.8.0",
-                "nette/reflection": "^2.4.2",
-                "php": ">=7.2.0",
-                "phpoption/phpoption": "^1.5.0",
-                "phpseclib/phpseclib": "^2.0.6",
-                "squizlabs/php_codesniffer": "^3.0.0",
-                "symfony/config": "^3.3.8",
-                "symfony/console": "^3.3.8",
-                "symfony/finder": "^3.3.8",
-                "symfony/process": "^3.3.8",
-                "symfony/yaml": "^3.3.8"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2.3"
-            },
-            "bin": [
-                "bin/bgawb"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/BGAWorkbench/Test/HamcrestMatchers/hasEntries.php",
-                    "src/BGAWorkbench/Test/HamcrestMatchers/hasKeys.php"
-                ],
-                "psr-4": {
-                    "BGAWorkbench\\": "src/BGAWorkbench"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Holmes",
-                    "email": "daniel@danielholmes.org"
-                }
-            ],
-            "description": "BoardGameArena Workbench",
-            "support": {
-                "issues": "https://github.com/danielholmes/bga-workbench/issues",
-                "source": "https://github.com/danielholmes/bga-workbench/tree/v0.2.1"
-            },
-            "time": "2021-06-01T23:35:35+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -218,10 +146,6 @@
                 "redis",
                 "xcache"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/2.1.1"
-            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -464,10 +388,6 @@
                 "event system",
                 "events"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
-            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -560,10 +480,6 @@
                 "uppercase",
                 "words"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/1.4.4"
-            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -698,10 +614,6 @@
                 "faker",
                 "fixtures"
             ],
-            "support": {
-                "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
-            },
             "abandoned": true,
             "time": "2020-12-11T09:56:16+00:00"
         },
@@ -750,10 +662,6 @@
             "keywords": [
                 "test"
             ],
-            "support": {
-                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
-            },
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
@@ -798,10 +706,6 @@
             ],
             "description": "The Illuminate Contracts package.",
             "homepage": "https://laravel.com",
-            "support": {
-                "issues": "https://github.com/laravel/framework/issues",
-                "source": "https://github.com/laravel/framework"
-            },
             "time": "2018-03-20T15:34:35+00:00"
         },
         {
@@ -852,10 +756,6 @@
             ],
             "description": "The Illuminate Filesystem package.",
             "homepage": "https://laravel.com",
-            "support": {
-                "issues": "https://github.com/laravel/framework/issues",
-                "source": "https://github.com/laravel/framework"
-            },
             "time": "2018-02-07T00:04:00+00:00"
         },
         {
@@ -913,10 +813,6 @@
             ],
             "description": "The Illuminate Support package.",
             "homepage": "https://laravel.com",
-            "support": {
-                "issues": "https://github.com/laravel/framework/issues",
-                "source": "https://github.com/laravel/framework"
-            },
             "time": "2018-08-10T19:40:01+00:00"
         },
         {
@@ -960,10 +856,6 @@
                 "laravel",
                 "resource"
             ],
-            "support": {
-                "issues": "https://github.com/jasonlewis/resource-watcher/issues",
-                "source": "https://github.com/jasonlewis/resource-watcher/tree/master"
-            },
             "time": "2015-07-11T10:22:48+00:00"
         },
         {
@@ -1009,10 +901,6 @@
                 }
             ],
             "description": "Update helper",
-            "support": {
-                "issues": "https://github.com/kylekatarnls/update-helper/issues",
-                "source": "https://github.com/kylekatarnls/update-helper/tree/1.2.1"
-            },
             "funding": [
                 {
                     "url": "https://github.com/kylekatarnls",
@@ -1165,10 +1053,6 @@
             "keywords": [
                 "functional"
             ],
-            "support": {
-                "issues": "https://github.com/lstrojny/functional-php/issues",
-                "source": "https://github.com/lstrojny/functional-php/tree/master"
-            },
             "time": "2018-01-03T10:08:50+00:00"
         },
         {
@@ -1289,10 +1173,6 @@
                 "datetime",
                 "time"
             ],
-            "support": {
-                "issues": "https://github.com/briannesbitt/Carbon/issues",
-                "source": "https://github.com/briannesbitt/Carbon"
-            },
             "time": "2019-10-14T05:51:36+00:00"
         },
         {
@@ -1360,10 +1240,6 @@
                 "nette",
                 "sqlite"
             ],
-            "support": {
-                "issues": "https://github.com/nette/caching/issues",
-                "source": "https://github.com/nette/caching/tree/v3.1.2"
-            },
             "time": "2021-08-24T23:45:03+00:00"
         },
         {
@@ -1427,10 +1303,6 @@
                 "iterator",
                 "nette"
             ],
-            "support": {
-                "issues": "https://github.com/nette/finder/issues",
-                "source": "https://github.com/nette/finder/tree/v2.5.3"
-            },
             "time": "2021-12-12T17:43:24+00:00"
         },
         {
@@ -1495,10 +1367,6 @@
                 "nette",
                 "reflection"
             ],
-            "support": {
-                "issues": "https://github.com/nette/reflection/issues",
-                "source": "https://github.com/nette/reflection/tree/master"
-            },
             "abandoned": true,
             "time": "2017-07-11T19:28:57+00:00"
         },
@@ -1581,10 +1449,6 @@
                 "utility",
                 "validation"
             ],
-            "support": {
-                "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v3.2.7"
-            },
             "time": "2022-01-24T11:29:14+00:00"
         },
         {
@@ -1636,10 +1500,6 @@
                 "parser",
                 "php"
             ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v3.1.5"
-            },
             "time": "2018-02-28T20:30:58+00:00"
         },
         {
@@ -1968,10 +1828,6 @@
                 "php",
                 "type"
             ],
-            "support": {
-                "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.8.1"
-            },
             "funding": [
                 {
                     "url": "https://github.com/GrahamCampbell",
@@ -2073,10 +1929,6 @@
                 "x.509",
                 "x509"
             ],
-            "support": {
-                "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.37"
-            },
             "funding": [
                 {
                     "url": "https://github.com/terrafrost",
@@ -2596,10 +2448,6 @@
                 "container-interop",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
-            },
             "time": "2021-11-05T16:50:12+00:00"
         },
         {
@@ -2647,9 +2495,6 @@
                 "psr",
                 "psr-3"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
             "time": "2021-05-03T11:20:27+00:00"
         },
         {
@@ -2698,9 +2543,6 @@
                 "psr-16",
                 "simple-cache"
             ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
-            },
             "time": "2017-10-23T01:57:42+00:00"
         },
         {
@@ -3433,6 +3275,82 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "splittingred/bga-workbench",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/splittingred/bga-workbench.git",
+                "reference": "3cd12ead8780f8d332ab0681f1f8defc86597733"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/splittingred/bga-workbench/zipball/3cd12ead8780f8d332ab0681f1f8defc86597733",
+                "reference": "3cd12ead8780f8d332ab0681f1f8defc86597733",
+                "shasum": ""
+            },
+            "require": {
+                "classpreloader/classpreloader": "^3.1.0",
+                "doctrine/dbal": "^2.5.12",
+                "ext-mysqli": "*",
+                "ext-pdo_mysql": "*",
+                "fzaninotto/faker": "^1.7.1",
+                "hamcrest/hamcrest-php": "^2.0.0",
+                "illuminate/support": ">=4.0 < 6.0.0",
+                "jasonlewis/resource-watcher": "1.2.0",
+                "lstrojny/functional-php": ">=1.6.0 <1.8.0",
+                "nette/reflection": "^2.4.2",
+                "php": ">=7.2.0",
+                "phpoption/phpoption": "^1.5.0",
+                "phpseclib/phpseclib": "^2.0.6",
+                "squizlabs/php_codesniffer": "^3.0.0",
+                "symfony/config": "^3.3.8",
+                "symfony/console": "^3.3.8",
+                "symfony/finder": "^3.3.8",
+                "symfony/process": "^3.3.8",
+                "symfony/yaml": "^3.3.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2.3"
+            },
+            "default-branch": true,
+            "bin": [
+                "bin/bgawb"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BGAWorkbench\\": "src/BGAWorkbench"
+                },
+                "files": [
+                    "src/BGAWorkbench/Test/HamcrestMatchers/hasEntries.php",
+                    "src/BGAWorkbench/Test/HamcrestMatchers/hasKeys.php"
+                ]
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Holmes",
+                    "email": "daniel@danielholmes.org"
+                },
+                {
+                    "name": "Shaun McCormick",
+                    "email": "blue@splittingred.com"
+                }
+            ],
+            "description": "BoardGameArena Workbench",
+            "support": {
+                "source": "https://github.com/splittingred/bga-workbench/tree/0.2.2"
+            },
+            "time": "2022-10-31T18:01:30+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.6.2",
             "source": {
@@ -3481,11 +3399,6 @@
                 "phpcs",
                 "standards"
             ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
             "time": "2021-12-12T21:44:58+00:00"
         },
         {
@@ -3545,9 +3458,6 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/config/tree/v3.4.47"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3629,9 +3539,6 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v3.4.47"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3697,9 +3604,6 @@
             ],
             "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/debug/tree/v4.4.41"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3714,6 +3618,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": "symfony/error-handler",
             "time": "2022-04-12T15:19:55+00:00"
         },
         {
@@ -3760,9 +3665,6 @@
             ],
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v4.4.39"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3821,9 +3723,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v3.4.47"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3986,9 +3885,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4069,9 +3965,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4130,9 +4023,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v3.4.47"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4219,9 +4109,6 @@
             ],
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/translation/tree/v4.4.41"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4297,9 +4184,6 @@
                 "interoperability",
                 "standards"
             ],
-            "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.1"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4368,9 +4252,6 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v3.4.47"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -4497,8 +4378,10 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "splittingred/bga-workbench": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -17,10 +17,11 @@
   */
 
 
+use Doctrine\DBAL\Connection;
+use Innovation\Cards;
+
 require_once(APP_GAMEMODULE_PATH.'module/table/table.game.php');
-require_once('modules/Innovation/Utils/Arrays.php');
-require_once('modules/Innovation/Utils/Strings.php');
-require_once('modules/Innovation/GameState.php');
+require_once('modules/loader.php');
 
 /* Exception to be called when the game must end */
 class EndOfGame extends Exception {}
@@ -29,9 +30,12 @@ class Innovation extends Table
 {
     /** @var \Innovation\GameState An inverted control structure for accessing game state in a testable manner */
     private \Innovation\GameState $innovationGameState;
+    /** @var Cards Service class for accessing cards */
+    private Cards $cards;
 
     function __construct()
     {
+        $this->textual_card_infos = [];
         // Your global variables labels:
         //  Here, you can assign labels to global variables you are using for this game.
         //  You can use any number of global variables with IDs between 10 and 99.
@@ -40,6 +44,8 @@ class Innovation extends Table
         // Note: afterwards, you can get/set the global variables with getGameStateValue/setGameStateInitialValue/setGameStateValue
         parent::__construct();
         $this->innovationGameState = new \Innovation\GameState($this);
+        $this->cards = new Cards($this->getDatabaseConnection());
+
         self::initGameStateLabels(array(
             'number_of_achievements_needed_to_win' => 10,
             'turn0' => 11,
@@ -133,6 +139,20 @@ class Innovation extends Table
     protected function getGameName()
     {
         return "innovation";
+    }
+
+    /**
+     * Return the DB connection object, allowing passing it to delegative models
+     *
+     * @return Connection
+     * @throws ReflectionException
+     */
+    public function getDatabaseConnection(): Connection
+    {
+        $reflector = new ReflectionObject($this);
+        $method = $reflector->getMethod('getDbConnection');
+        $method->setAccessible(true);
+        return $method->invoke($this);
     }
 
     function upgradeTableDb($from_version) {
@@ -3419,11 +3439,11 @@ class Innovation extends Table
     }
 
     function getCardName($id) {
-        return $this->textual_card_infos[$id]['name'];
+        return $this->textual_card_infos[$id]['name'] ?? '';
     }
 
     function getAchievementCardName($id) {
-        return $this->textual_card_infos[$id]['achievement_name'];
+        return $this->textual_card_infos[$id]['achievement_name'] ?? '';
     }
 
     function getNonDemandEffect($id, $effect_number) {
@@ -6074,15 +6094,16 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         (note: each method below must match an input method in innovation.action.php)
     */
     
-    function initialMeld($card_id) {
+    public function initialMeld($card_id): void
+    {
         // Check that this is the player's turn and that it is a "possible action" at this game state
         self::checkAction('initialMeld');
         $player_id = self::getCurrentPlayerId();
 
         // Check if the player really has this card
-        $card = self::getCardInfo($card_id);
-        
-        if ($card['owner'] != $player_id || $card['location'] != "hand") {
+        $card = $this->cards->find($card_id);
+        if (!$card->isOwner($player_id) || !$card->isInHand())
+        {
             self::throwInvalidChoiceException();
         }
         
@@ -6093,7 +6114,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         }
         
         // Mark it as selected
-        self::markAsSelected($card_id, $player_id);
+        self::markAsSelected($card_id);
         
         // Notify
         self::notifyPlayer($player_id, 'log', clienttranslate('${You} choose a card.'), array(

--- a/modules/Innovation/Cards.php
+++ b/modules/Innovation/Cards.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Innovation;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DbException;
+use Innovation\Errors\CardNotFoundException;
+use Innovation\Models\Card;
+
+/**
+ * Service class for finding Cards in the database. Also illustrates inversion of control and how to pass the
+ * database connection using dependency injection. This separates out of the main Innovation class the logic for
+ * dealing with Cards, allowing DB queries around cards to be located here, and then returning model objects for each
+ * card.
+ *
+ * @see \Innovation\Models\Card
+ */
+class Cards
+{
+    private Connection $db;
+
+    public function __construct(Connection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * Return a card given an ID
+     *
+     * @param int $id
+     * @return Card
+     * @throws CardNotFoundException
+     */
+    public function find(int $id): Card
+    {
+        $card = null;
+        try {
+            $card = $this->db->fetchAssociative("SELECT * FROM card WHERE id = ?", [$id]);
+        } catch (DbException $e) {
+            // TODO: add a logger class to log this error, this is an exceptional case
+        }
+        if ($card) {
+            return new Card($card);
+        } else {
+            throw new CardNotFoundException("Failed to find card with id $id");
+        }
+    }
+}

--- a/modules/Innovation/Errors/CardNotFoundException.php
+++ b/modules/Innovation/Errors/CardNotFoundException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Innovation\Errors;
+
+use BgaSystemException;
+
+class CardNotFoundException extends BgaSystemException {}

--- a/modules/Innovation/Models/Card.php
+++ b/modules/Innovation/Models/Card.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Innovation\Models;
+
+/**
+ * Represents a Card in the database.
+ */
+class Card
+{
+    const SPLAY_NONE = 0;
+    const SPLAY_LEFT = 1;
+    const SPLAY_RIGHT = 2;
+    const SPLAY_UP = 3;
+    const SPLAY_NOT_ON_BOARD = null;
+    const LOCATION_HAND = 'hand';
+
+    private int $id;
+    private int $type;
+    private int $age;
+    private int $faceUpAge;
+    private int $color;
+    private int $spot1;
+    private int $spot2;
+    private int $spot3;
+    private int $spot4;
+    private int $spot5;
+    private int $spot6;
+    private int $dogmaIcon;
+    private bool $hasDemand;
+    private bool $isRelic;
+    private int $ownerId;
+    private string $location;
+    private int $position;
+    private int $splayDirection;
+    private bool $selected;
+    private int $iconHash;
+
+    /**
+     * @param array $data
+     */
+    public function __construct(array $data = [])
+    {
+        $this->id = (int)($data['id'] ?? 0);
+        $this->type = (int)($data['type'] ?? 0);
+        $this->age = (int)($data['age'] ?? 0);
+        $this->faceUpAge = (int)($data['faceup_age'] ?? 0);
+        $this->color = (int)($data['color'] ?? 0);
+        $this->spot1 = (int)($data['spot_1'] ?? 0);
+        $this->spot2 = (int)($data['spot_2'] ?? 0);
+        $this->spot3 = (int)($data['spot_3'] ?? 0);
+        $this->spot4 = (int)($data['spot_4'] ?? 0);
+        $this->spot5 = (int)($data['spot_5'] ?? 0);
+        $this->spot6 = (int)($data['spot_6'] ?? 0);
+        $this->dogmaIcon = (int)($data['dogma_icon'] ?? 0);
+        $this->hasDemand = !empty($data['has_demand']);
+        $this->isRelic = !empty($data['is_relic']);
+        $this->ownerId = (int)($data['owner']);
+        $this->location = (string)($data['location'] ?? '');
+        $this->position = (int)($data['position'] ?? 0);
+        $this->splayDirection = (int)($data['splay_direction'] ?? 0);
+        $this->selected = !empty($data['selected']);
+        $this->iconHash = (int)($data['icon_hash'] ?? 0);
+    }
+
+    /**
+     * @return bool True if the card is splayed left
+     */
+    public function isSplayedLeft(): bool
+    {
+        return $this->getSplayDirection() == self::SPLAY_LEFT;
+    }
+
+    /**
+     * @return bool True if the card is splayed right
+     */
+    public function isSplayedRight(): bool
+    {
+        return $this->getSplayDirection() == self::SPLAY_RIGHT;
+    }
+
+    /**
+     * @return bool True if the card is splayed up
+     */
+    public function isSplayedUp(): bool
+    {
+        return $this->getSplayDirection() == self::SPLAY_UP;
+    }
+
+    /**
+     * @return bool True if the card is not splayed
+     */
+    public function isNotSplayed(): bool
+    {
+        return $this->getSplayDirection() == self::SPLAY_NONE;
+    }
+
+    /**
+     * Is the passed player the owner of this card?
+     *
+     * @param int $playerId
+     * @return bool
+     */
+    public function isOwner(int $playerId): bool
+    {
+        return $this->getOwnerId() == $playerId;
+    }
+
+    /**
+     * Is this card in the player's hand?
+     *
+     * @return bool
+     */
+    public function isInHand(): bool
+    {
+        return $this->getLocation() == self::LOCATION_HAND;
+    }
+
+    /*******************************************************************************************************************
+     * GETTER METHODS
+     ******************************************************************************************************************/
+
+    /**
+     * 0-104 for base cards, 105-109 for base special achievements, 110-214 for artifact cards, 215-219 for relics
+     *
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     *
+     * 0 for base, 1 for artifacts, 2 for cities, 3 for echoes, 4 for figures
+     *
+     * @return int
+     */
+    public function getType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * 1 to 10, NULL for a special achievement
+     *
+     * @return int
+     */
+    public function getAge(): int
+    {
+        return $this->age;
+    }
+
+    /**
+     * The same as age, except Battleship Yamato is an 11 instead of 8 (dynamically populated)
+     *
+     * @return int
+     */
+    public function getFaceUpAge(): int
+    {
+        return $this->faceUpAge;
+    }
+
+    /**
+     * 0 (blue), 1 (red), 2 (green), 3 (yellow), 4 (purple) or NULL for a special achievement
+     *
+     * @return int
+     */
+    public function getColor(): int
+    {
+        return $this->color;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSpot1(): int
+    {
+        return $this->spot1;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSpot2(): int
+    {
+        return $this->spot2;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSpot3(): int
+    {
+        return $this->spot3;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSpot4(): int
+    {
+        return $this->spot4;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSpot5(): int
+    {
+        return $this->spot5;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSpot6(): int
+    {
+        return $this->spot6;
+    }
+
+    /**
+     * Feature icon for dogma, 1 (crown), 2 (leaf), 3 (bulb), 4 (tower), 5 (factory), 6 (clock) or NULL for no
+     * icon (e.g. special achievement)
+     *
+     * @return int
+     */
+    public function getDogmaIcon(): int
+    {
+        return $this->dogmaIcon;
+    }
+
+    /**
+     * Whether the card has at least one demand effect (will be populated using data in material.inc.php file)
+     *
+     * @return bool
+     */
+    public function isHasDemand(): bool
+    {
+        return $this->hasDemand;
+    }
+
+    /**
+     * Whether or not the card is a relic
+     *
+     * @return bool
+     */
+    public function isRelic(): bool
+    {
+        return $this->isRelic;
+    }
+
+    /**
+     * Id of the player who owns the card or 0 if no owner
+     *
+     * @return int
+     */
+    public function getOwnerId(): int
+    {
+        return $this->ownerId;
+    }
+
+    /**
+     * Hand, board, score, achievements, deck, display or revealed (achievements can be used both with owner = 0
+     * (available achievement) or with a player as owner (the player has earned that achievement)
+     *
+     * @return string
+     */
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    /**
+     * Position in the given location. Bottom is zero (last card in deck), top is max. For hands, the cards are sorted
+     * by age before being sorted by position. For boards, the positions reflect the order in the stacks, 0 for the
+     * bottom card, maximum for active card.
+     *
+     * @return int
+     */
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * Direction of the splay, 0 (no-splay), 1 (left), 2 (right), 3 (up) OR NULL if this card is not on board
+     *
+     * @return int
+     */
+    public function getSplayDirection(): int
+    {
+        return $this->splayDirection;
+    }
+
+    /**
+     * Temporary flag to indicate whether the card is selected by its owner or not
+     *
+     * @return bool
+     */
+    public function isSelected(): bool
+    {
+        return $this->selected;
+    }
+
+    /**
+     * A column that is updated on game start with a calculated hash of the card icons. This is for icon comparison
+     * purposes regardless of the icon position.
+     *
+     * @return int
+     */
+    public function getIconHash(): int
+    {
+        return $this->iconHash;
+    }
+}

--- a/modules/loader.php
+++ b/modules/loader.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * For now, we can put all our includes here. Eventually, should investigate using Composer with bga-workbench
+ * to allow dynamically loading all these.
+ *
+ * Until then, every time you create a new file in `modules/`, make sure to add the require here.
+ */
+
+require_once('modules/Innovation/Errors/CardNotFoundException.php');
+require_once('modules/Innovation/Utils/Arrays.php');
+require_once('modules/Innovation/Utils/Strings.php');
+require_once('modules/Innovation/GameState.php');
+require_once('modules/Innovation/Models/Card.php');
+require_once('modules/Innovation/Cards.php');

--- a/tests/Helpers/WithTable.php
+++ b/tests/Helpers/WithTable.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Helpers;
+
+use BGAWorkbench\External\WorkbenchProjectConfigSerialiser;
+use BGAWorkbench\Project\WorkbenchProjectConfig;
+use BGAWorkbench\Test\TableInstance;
+use BGAWorkbench\Test\TableInstanceBuilder;
+
+trait WithTable
+{
+    /** @var TableInstance */
+    protected $table;
+    protected static $cwdConfig = null;
+
+    protected function setUp(): void
+    {
+        $this->table = $this->createGameTableInstanceBuilder()
+            ->build()
+            ->createDatabase();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->table !== null) {
+            $this->table->dropDatabaseAndDisconnect();
+        }
+    }
+
+    /**
+     * @return WorkbenchProjectConfig
+     */
+    private static function getCwdProjectConfig() : WorkbenchProjectConfig
+    {
+        if (self::$cwdConfig === null) {
+            self::$cwdConfig = WorkbenchProjectConfigSerialiser::readFromCwd();
+        }
+
+        return self::$cwdConfig;
+    }
+
+    /**
+     * @return TableInstanceBuilder
+     */
+    protected function gameTableInstanceBuilder() : TableInstanceBuilder
+    {
+        return TableInstanceBuilder::create(self::getCwdProjectConfig());
+    }
+}

--- a/tests/Unit/BaseTest.php
+++ b/tests/Unit/BaseTest.php
@@ -2,22 +2,37 @@
 
 namespace Unit;
 
-use BGAWorkbench\Test\StubProductionEnvironment;
+use BGAWorkbench\Test\TableInstanceBuilder;
 use Helpers\TestHelpers;
+use Helpers\WithTable;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseTest extends TestCase
 {
     use TestHelpers;
+    use WithTable;
+
+    protected function createGameTableInstanceBuilder() : TableInstanceBuilder
+    {
+        return $this->gameTableInstanceBuilder()
+            ->setPlayersWithIds([66, 77])
+            ->overridePlayersPostSetup([
+                66 => ['player_color' => 'ff0000'],
+                77 => ['player_color' => '00ff00']
+            ]);
+    }
 
     /**
      * Return \Innovation class, but as the user-specific name (to allow for easy dev workflow)
      *
-     * @return object
+     * @return \Innovation
      */
     public function getInnovationInstance()
     {
         $klass = BGA_GAME_CLASS;
+        $this->table = $this->createGameTableInstanceBuilder()->build();
+        $this->table->createDatabase();
+        $klass::setDbConnection($this->table->getDbConnection());
         return new $klass();
     }
 }

--- a/tests/Unit/GameTest.php
+++ b/tests/Unit/GameTest.php
@@ -4,11 +4,6 @@ namespace Unit;
 
 class GameTest extends BaseTest
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testGetArrayAsValue()
     {
         $array = [2,3,4];

--- a/tests/Unit/Innovation/CardsTest.php
+++ b/tests/Unit/Innovation/CardsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Unit\Innovation;
+
+use Innovation\Cards;
+use Innovation\Errors\CardNotFoundException;
+use Innovation\Models\Card;
+use Unit\BaseTest;
+
+class CardsTest extends BaseTest
+{
+    protected Cards $cards;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->cards = new Cards($this->table->getDbConnection());
+    }
+
+    public function testFindWhenCardExists()
+    {
+        $card = $this->cards->find(1);
+        $this->assertInstanceOf(Card::class, $card);
+        $this->assertEquals(1, $card->getId());
+    }
+
+    public function testFindWhenCardDoesNotExist()
+    {
+        $this->expectException(CardNotFoundException::class);
+
+        $card = $this->cards->find(9999999999);
+        $this->assertInstanceOf(Card::class, $card);
+        $this->assertEquals(1, $card->getId());
+    }
+}

--- a/tests/Unit/Innovation/Models/CardTest.php
+++ b/tests/Unit/Innovation/Models/CardTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Unit\Innovation\Models;
+
+use Innovation\Models\Card;
+use Unit\BaseTest;
+
+class CardTest extends BaseTest
+{
+    /**
+     * @dataProvider providerTestInHand
+     */
+    public function testIsInHandWhenInHand(bool $expectedValue, string $locationValue)
+    {
+        $this->table
+            ->setupNewGame()
+            ->createGameInstanceForCurrentPlayer(66)
+            ->stubActivePlayerId(66);
+        $card = $this->buildCard([
+            'location' => $locationValue,
+        ]);
+        $this->assertEquals($expectedValue, $card->isInHand());
+    }
+    public function providerTestInHand(): array
+    {
+        return [
+            [true, 'hand'],
+        ];
+    }
+
+    private function buildCard(array $data = []): Card
+    {
+        $data['id'] = (int)($data['id'] ?? rand(1, 100000));
+        $data['type'] = (int)($data['type'] ?? 0);
+        $data['age'] = (int)($data['age'] ?? 1);
+        $data['faceup_age'] = (int)($data['faceup_age'] ?? 1);
+        $data['color'] = (int)($data['color'] ?? 0);
+        $data['spot_1'] = (int)($data['spot_1'] ?? 2);
+        $data['spot_2'] = (int)($data['spot_2'] ?? 2);
+        $data['spot_3'] = (int)($data['spot_3'] ?? 2);
+        $data['spot_4'] = (int)($data['spot_4'] ?? -1);
+        $data['spot_5'] = (int)($data['spot_5'] ?? -1);
+        $data['spot_6'] = (int)($data['spot_6'] ?? -1);
+        $data['dogma_icon'] = (int)($data['dogma_icon'] ?? 0);
+        $data['has_demand'] = !empty($data['has_demand']);
+        $data['is_relic'] = !empty($data['is_relic']);
+        $data['owner'] = (int)($data['owner'] ?? 1);
+        $data['location'] = empty($data['location']) ? '' : $data['location'];
+        $data['position'] = (int)($data['position'] ?? 0);
+        $data['splay_direction'] = (int)($data['splay_direction'] ?? 0);
+        $data['selected'] = !empty($data['selected']);
+        $data['icon_hash'] = (int)($data['icon_hash'] ?? 0);
+        return new Card($data);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,11 @@
 
 use BGAWorkbench\Test\StubProductionEnvironment;
 
+error_reporting(E_ALL | E_STRICT);
+ini_set('display_errors', 1);
+
+$_ENV['TEST'] = '1';
+
 // We're on GitHub Actions, so do this statically since the directory structure there is different
 $ci = getenv('CI');
 if (!empty($ci)) {
@@ -15,12 +20,11 @@ if (!empty($ci)) {
 define('BGA_GAME_NAME', $gameName);
 define('BGA_GAME_CLASS', ucfirst($gameName));
 
-error_reporting(E_ALL | E_STRICT);
-ini_set('display_errors', 1);
 $vendorDir = __DIR__ . '/../vendor';
 require_once $vendorDir . '/autoload.php';
 require_once 'Helpers/Mocks.php';
 require_once 'Helpers/TestHelpers.php';
+require_once 'Helpers/WithTable.php';
 
-StubProductionEnvironment::stub();
+StubProductionEnvironment::stub(); // defines APP_GAMEMODULE_PATH & some BGA classes mocks
 require_once "$gameName.game.php";


### PR DESCRIPTION
## What?

* Adds the ability to test against the database. Detailed in README, but copy `bgaproject.dist.yml` to `bgaproject.yml`, set your settings, then run `./vendor/bin/phpunit` to see it in action.
* Note that the bgaproject.yml implementation here is just for testing; not used in actual runtime (could be! it has deploy functionality but not using it now)
* Adds a new `Card` model and `\Innovation\Cards` service for getting a Card model, which can then be used elsewhere (with programmatic type enforcement!)
* Added a `getDatabaseConnection` method to the main `\Innovation` class to allow to inject that into other classes (such as a service class) so you can issue DB queries without needing the main class to do so. (BGA uses Doctrine's DBAL under the hood)
* Using my fork of the bga-workbench which has a bunch of fixes and quality-of-life improvements to it, which also allows it to work on Github CI (for automated tests)

I don't have a separate Innovation game on BGA setup at present, so I didn't test actually trying this out on a deployed Innovation game instance on BGA. But, there was some discussion in the Discord about this so I thought I'd show how it can happen.