### PR TITLE
Add special achievement check after every transfer (#753, #764)

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -6906,16 +6906,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
         self::incStat(1, 'promoted_number', $player_id);
 
-        try {
-            self::checkForSpecialAchievements();
-        } catch (EndOfGame $e) {
-            // End of the game: the exception has reached the highest level of code
-            self::trace('EOG bubbled from self::meld');
-            self::trace('promoteCardPlayerTurn->justBeforeGameEnd');
-            $this->gamestate->nextState('justBeforeGameEnd');
-            return;
-        }
-
         self::trace('promoteCardPlayerTurn->promoteDogmaPlayerTurn (promoteCard)');
         $this->gamestate->nextState('promoteDogmaPlayerTurn');
     }
@@ -7041,17 +7031,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         $previous_top_card = self::getTopCardOnBoard($card['owner'], $card['color']);
         // Execute the meld
         self::transferCardFromTo($card, $card['owner'], 'board');
-        
-        try {
-            self::checkForSpecialAchievements();
-        } catch (EndOfGame $e) {
-            // End of the game: the exception has reached the highest level of code
-            self::trace('EOG bubbled from self::meld');
-            self::trace('playerTurn->justBeforeGameEnd');
-            $this->gamestate->nextState('justBeforeGameEnd');
-            return;
-        }
-
         self::setGameStateValue('melded_card_id', $card['id']);
         
         // Execute city's icon effect
@@ -14365,16 +14344,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
     }
     
     function stInterPlayerInvolvedTurn() {
-        
-        try {
-            self::checkForSpecialAchievements();
-        } catch (EndOfGame $e) {
-            // End of the game: the exception has reached the highest level of code
-            self::trace('EOG bubbled from self::stInterPlayerInvolvedTurn');
-            self::trace('interPlayerInvolvedTurn->justBeforeGameEnd');
-            $this->gamestate->nextState('justBeforeGameEnd');
-            return;
-        }
 
         // Switch to new card that was pushed onto the stack
         if (self::getNestedCardState(self::getGameStateValue('current_nesting_index') + 1) != null) {

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -6906,6 +6906,16 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
         self::incStat(1, 'promoted_number', $player_id);
 
+        try {
+            self::checkForSpecialAchievements(/*onlyImmediateAchievements=*/ false);
+        } catch (EndOfGame $e) {
+            // End of the game: the exception has reached the highest level of code
+            self::trace('EOG bubbled from self::meld');
+            self::trace('promoteCardPlayerTurn->justBeforeGameEnd');
+            $this->gamestate->nextState('justBeforeGameEnd');
+            return;
+        }
+
         self::trace('promoteCardPlayerTurn->promoteDogmaPlayerTurn (promoteCard)');
         $this->gamestate->nextState('promoteDogmaPlayerTurn');
     }

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -1828,7 +1828,7 @@ class Innovation extends Table
         }
 
         try {
-            self::checkForSpecialAchievements(/*onlyImmediateAchievements=*/ true);
+            self::checkForSpecialAchievements();
         } catch(EndOfGame $e) {
             $end_of_game = true;
         }
@@ -3104,20 +3104,20 @@ class Innovation extends Table
     }
 
     /** Checks to see if any players are eligible for special achievements. **/
-    function checkForSpecialAchievements($onlyImmediateAchievements) {
+    function checkForSpecialAchievements() {
         // "In the rare case that two players simultaneously become eligible to claim a special achievement,
         // the tie is broken in turn order going clockwise, with the current player winning ties."
         // https://boardgamegeek.com/thread/2710666/simultaneous-special-achievements-tiebreaker
         foreach (self::getActivePlayerIdsInTurnOrderStartingWithCurrentPlayer() as $player_id) {
-            self::checkForSpecialAchievementsForPlayer($player_id, $onlyImmediateAchievements);
+            self::checkForSpecialAchievementsForPlayer($player_id);
         }
     }
     
     /** Checks if the player meets the conditions to get a special achievement. Do the transfer if he does. **/
-    function checkForSpecialAchievementsForPlayer($player_id, $onlyImmediateAchievements) {
+    function checkForSpecialAchievementsForPlayer($player_id) {
         // TODO(FIGURES): Update this once there are other special achievements to test for.
-        $achievements_to_test = $onlyImmediateAchievements ? array(106) : array(105, 106, 107, 108, 109);
-        if (self::getGameStateValue('echoes_mode') > 1 && !$onlyImmediateAchievements) {
+        $achievements_to_test = array(105, 106, 107, 108, 109);
+        if (self::getGameStateValue('echoes_mode') > 1) {
             $achievements_to_test = array_merge($achievements_to_test, [435, 436, 437, 438, 439]);
         }
         $end_of_game = false;
@@ -6907,7 +6907,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         self::incStat(1, 'promoted_number', $player_id);
 
         try {
-            self::checkForSpecialAchievements(/*onlyImmediateAchievements=*/ false);
+            self::checkForSpecialAchievements();
         } catch (EndOfGame $e) {
             // End of the game: the exception has reached the highest level of code
             self::trace('EOG bubbled from self::meld');
@@ -7043,7 +7043,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         self::transferCardFromTo($card, $card['owner'], 'board');
         
         try {
-            self::checkForSpecialAchievements(/*onlyImmediateAchievements=*/ false);
+            self::checkForSpecialAchievements();
         } catch (EndOfGame $e) {
             // End of the game: the exception has reached the highest level of code
             self::trace('EOG bubbled from self::meld');
@@ -10676,28 +10676,29 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
             // id 78, age 8: Mobility        
             case "78D1":
                 // "I demand you transfer the two highest non-red top cards without a factory from your board to my score pile!"
+                // TODO(LATER): Uncomment this for the 4th edition once order no longer matters forspecial achievement eligiblity
                 // NOTE: This code is only here in order to add automation to the situation where there is no choice for which two
                 // cards need to be transferred. Generic automation is not possible here because we must implement the card as two
                 // separate interactions instead of a single interaction which returns two cards.
-                $top_cards = self::getTopCardsOnBoard($player_id);
-                $selectable_cards = array();
-                for ($age = 11; $age >= 1; $age--) {
-                    foreach ($top_cards as $top_card) {
-                        if ($top_card['faceup_age'] == $age && $top_card['color'] != 1 && !self::hasRessource($top_card, 5)) {
-                            $selectable_cards[] = $top_card;
-                        }
-                    }
-                    if (count($selectable_cards) == 2) {
-                        foreach ($selectable_cards as $card) {
-                            self::transferCardFromTo($card, $launcher_id, 'score', /*bottom_to=*/ false, /*score_keyword=*/ false);
-                        }
-                        // "If you transferred any cards, draw an 8"
-                        self::executeDraw($player_id, 8);
-                        break 2; // Exit the for loop and the switch
-                    } else if (count($selectable_cards) > 2) {
-                        break;
-                    }
-                }
+                // $top_cards = self::getTopCardsOnBoard($player_id);
+                // $selectable_cards = array();
+                // for ($age = 11; $age >= 1; $age--) {
+                //     foreach ($top_cards as $top_card) {
+                //         if ($top_card['faceup_age'] == $age && $top_card['color'] != 1 && !self::hasRessource($top_card, 5)) {
+                //             $selectable_cards[] = $top_card;
+                //         }
+                //     }
+                //     if (count($selectable_cards) == 2) {
+                //         foreach ($selectable_cards as $card) {
+                //             self::transferCardFromTo($card, $launcher_id, 'score', /*bottom_to=*/ false, /*score_keyword=*/ false);
+                //         }
+                //         // "If you transferred any cards, draw an 8"
+                //         self::executeDraw($player_id, 8);
+                //         break 2; // Exit the for loop and the switch
+                //     } else if (count($selectable_cards) > 2) {
+                //         break;
+                //     }
+                // }
 
                 // Proceed without automation
                 self::setAuxiliaryValueFromArray(array(0,2,3,4)); // Flag to indicate the colors the player can still choose (not red at the start)
@@ -14366,7 +14367,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
     function stInterPlayerInvolvedTurn() {
         
         try {
-            self::checkForSpecialAchievements(/*onlyImmediateAchievements=*/ false);
+            self::checkForSpecialAchievements();
         } catch (EndOfGame $e) {
             // End of the game: the exception has reached the highest level of code
             self::trace('EOG bubbled from self::stInterPlayerInvolvedTurn');
@@ -14862,7 +14863,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_from' => $player_id,
                 'location_from' => 'score',
                 'owner_to' => $player_id,
-                'location_to' => 'board'
+                'location_to' => 'board',
+
+                'enable_autoselection' => false, // Meld order can affect special achievement eligiblity
             );
             break;
         
@@ -15504,7 +15507,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => $player_id,
                 'location_to' => 'board',
                 
-                'age' => self::getMaxAgeInScore($player_id)
+                'age' => self::getMaxAgeInScore($player_id),
+
+                'enable_autoselection' => false, // Meld order can affect special achievement eligiblity
             );
             break;
         
@@ -15545,7 +15550,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => $player_id,
                 'location_to' => 'board',
                 
-                'color' => array(self::getAuxiliaryValue()) /* The color the player has revealed */
+                'color' => array(self::getAuxiliaryValue()), /* The color the player has revealed */
+
+                'enable_autoselection' => false, // Meld order can affect special achievement eligiblity
             );
             break;
         
@@ -15753,7 +15760,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => 0,
                 'location_to' => 'deck',
                 
-                'without_icon' => 5 /* factory */
+                'without_icon' => 5, /* factory */
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
             );
             break;
         
@@ -16056,6 +16065,8 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'deck',
                 
                 'color' => array(self::getAuxiliaryValue()), /* the color of the card chosen on the first step */
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
              );
             break;
         
@@ -16409,7 +16420,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => 0,
                 'location_to' => 'deck',
 
-                'has_demand_effect' => true
+                'has_demand_effect' => true,
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
             );
             break;
         
@@ -16777,7 +16790,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_from' => $player_id,
                 'location_from' => 'hand',
                 'owner_to' => $player_id,
-                'location_to' => 'board'
+                'location_to' => 'board',
+
+                'enable_autoselection' => false, // Meld order can affect special achievement eligiblity
             );
             break;
 
@@ -17419,7 +17434,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => 0,
                 'location_to' => 'deck',
 
-                'color' => array(1, 2, 3, 4) // non-blue
+                'color' => array(1, 2, 3, 4), // non-blue
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
             );
             break;
 
@@ -17642,7 +17659,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => 0,
                 'location_to' => 'deck',
                 
-                'color' => array(self::getGameStateValue('color_last_selected'))
+                'color' => array(self::getGameStateValue('color_last_selected')),
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
             );
             break;
 
@@ -17857,7 +17876,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => 0,
                 'location_to' => 'deck',
                 
-                'color' => array(self::getAuxiliaryValue())
+                'color' => array(self::getAuxiliaryValue()),
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
              );
             break;
             
@@ -18048,7 +18069,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => 0,
                 'location_to' => 'deck',
                 
-                'color' => array($card['color'])
+                'color' => array($card['color']),
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
             );
             break;
             
@@ -18171,7 +18194,9 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'owner_to' => $launcher_id,
                 'location_to' => 'score',
 
-                'has_demand_effect' => true
+                'has_demand_effect' => true,
+
+                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
             );
             break;
 
@@ -19167,6 +19192,8 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
 
                 'with_icon' => 4, /* tower */
+
+                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
             );
             break;
 
@@ -19395,6 +19422,8 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'deck',
 
                 'with_icon' => 4, /* tower */
+
+                'enable_autoselection' => false, // Return order can affect special achievement eligiblity
             );
             break;
 
@@ -20140,6 +20169,8 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
                 
                 'with_bonus' => true,
+
+                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
             );
             break;
 
@@ -21035,6 +21066,8 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
                 
                 'without_icon' => self::getAuxiliaryValue(),
+
+                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
              );
             break;
 

--- a/material.inc.php
+++ b/material.inc.php
@@ -527,7 +527,7 @@ $this->textual_card_infos = array(
 /* Special achievements */
 
 105 => array('name' => clienttranslate('Empire'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have three or more icons of all six types: ${icons_1_to_6}'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have three or more icons of all six types: ${icons_1_to_6}'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_2} Construction.')),
 
 106 => array('name' => clienttranslate('Monument'),
@@ -535,15 +535,15 @@ $this->textual_card_infos = array(
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_1} Masonry.')),
 
 107 => array('name' => clienttranslate('Wonder'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have five colors on your board, and each is splayed either up or right.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have five colors on your board, and each is splayed either up or right.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_4} Invention.')),
 
 108 => array('name' => clienttranslate('World'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have twelve or more ${icon_6} on your board.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have twelve or more ${icon_6} on your board.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_5} Translation.')),
 
 109 => array('name' => clienttranslate('Universe'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have five top cards, and each is of value ${age_8} or higher.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have five top cards, and each is of value ${age_8} or higher.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_5} Astronomy.')),
 
 /* Artifacts - Age 1 */
@@ -1754,23 +1754,23 @@ $this->textual_card_infos = array(
 /* Echoes - Special achievements */
 
 435 => array('name' => clienttranslate('Wealth'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have eight or more bonuses visible on your board.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have eight or more bonuses visible on your board.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_5} Palampore.')),
 
 436 => array('name' => clienttranslate('Destiny'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have seven or more cards in your forecast.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have seven or more cards in your forecast.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_4} Barometer.')),
 
 437 => array('name' => clienttranslate('Heritage'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have eight or more ${icon_0} visible in one color.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have eight or more ${icon_0} visible in one color.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_6} Loom.')),
 
 438 => array('name' => clienttranslate('History'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have a color with four or more visible echo effects.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have a color with four or more visible echo effects.'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_7} Photography.')),
 
 439 => array('name' => clienttranslate('Supremacy'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement if you have three icons or more of the same icon type visible in each of four different colors. (Each color has to have the same icon as the other colors.)'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have three icons or more of the same icon type visible in each of four different colors. (Each color has to have the same icon as the other colors.)'),
     'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_3} Novel.')),
 
 );


### PR DESCRIPTION
I also had to disable automation for certain cards since the selection order again matters for the purposes of special achievement eligibility. Fortunately, we are not disabling that much automation so this isn't a big deal.