### PR TITLE
Re-add automation to when cards are being moved to the score pile

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -18165,8 +18165,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
 
                 'has_demand_effect' => true,
-
-                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
             );
             break;
 
@@ -19162,8 +19160,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
 
                 'with_icon' => 4, /* tower */
-
-                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
             );
             break;
 
@@ -20139,8 +20135,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
                 
                 'with_bonus' => true,
-
-                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
             );
             break;
 
@@ -21036,8 +21030,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 'location_to' => 'score',
                 
                 'without_icon' => self::getAuxiliaryValue(),
-
-                'enable_autoselection' => false, // Transfer order can affect special achievement eligiblity
              );
             break;
 


### PR DESCRIPTION
This provides more consistency to how we decide when to automate cards.

I've chosen to do special achievement checks after every card transfer (or splay). Card transfers will be automated as much as possible, except if the cards are being returned (since the order affects the position that they end up in decks) or if they are being melded. In either of these cases, since we can't automate the entire sequence of transfers, we choose to give players control over the entire selection order for consistency.

I think the above gives us the best balance between automation and giving players control over the order (even though being clever about the selection order was never the intent of the game designer/publisher).