### PR TITLE
Add visual distinction when mid-dogma (#746)

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -998,13 +998,12 @@
 .clickable:hover {
   cursor: pointer;
 }
-
-.selected {
-  box-shadow: 0 0 6px 3px #b20a0a !important;
+.clickable.mid_dogma {
+  box-shadow: 0 0 6px 3px #9a0505 !important;
 }
 
-.clickable_important {
-  box-shadow: 0 0 6px 3px #b20a0a !important;
+.selected {
+  box-shadow: 0 0 6px 3px black !important;
 }
 
 .splay_indicator {

--- a/innovation.js
+++ b/innovation.js
@@ -130,7 +130,7 @@ function (dojo, declare) {
             
             // System to remember what node where last offed and what was their handlers to restore if needed
             this.deactivated_cards = null;
-            this.deactivated_cards_important = null;
+            this.deactivated_cards_mid_dogma = null;
             this.erased_pagemaintitle_text = null;
         },
         
@@ -1023,7 +1023,7 @@ function (dojo, declare) {
                     // Claimable achievements (achieve action)
                     if (args.args.claimable_ages.length > 0) {
                         var claimable_achievements = this.selectClaimableAchievements(args.args.claimable_ages);
-                        claimable_achievements.addClass("clickable").addClass("clickable_important");
+                        claimable_achievements.addClass("clickable");
                         this.on(claimable_achievements, 'onclick', 'action_clicForAchieve');
                     }
                     
@@ -1062,7 +1062,7 @@ function (dojo, declare) {
                         // Allowed selected cards by the server
                         var visible_selectable_cards = this.selectCardsFromList(args.args._private.visible_selectable_cards);
                         if (visible_selectable_cards !== null) {
-                            visible_selectable_cards.addClass("clickable");
+                            visible_selectable_cards.addClass("clickable").addClass('mid_dogma');
                             this.on(visible_selectable_cards, 'onclick', 'action_clicForChoose');
                             if (args.args._private.must_show_score && !this.isInReplayMode()) {
                                 this.my_score_verso_window.show();
@@ -1070,7 +1070,7 @@ function (dojo, declare) {
                         }
                         var selectable_rectos = this.selectRectosFromList(args.args._private.selectable_rectos);
                         if (selectable_rectos !== null) {
-                            selectable_rectos.addClass("clickable");
+                            selectable_rectos.addClass("clickable").addClass('mid_dogma');
                             this.on(selectable_rectos, 'onclick', 'action_clicForChooseRecto');
                         }
                         if (args.args._private.show_all_cards_on_board) {
@@ -1100,7 +1100,7 @@ function (dojo, declare) {
                         this.publication_permutations_done = [];
                         
                         var selectable_cards = this.selectAllCardsOnMyBoard();
-                        selectable_cards.addClass("clickable");
+                        selectable_cards.addClass("clickable").addClass('mid_dogma');
                         this.on(selectable_cards, 'onclick', 'publicationClicForMove');
                     }
                     
@@ -2104,9 +2104,9 @@ function (dojo, declare) {
         deactivateClickEvents : function() {
             this.deactivated_cards = dojo.query(".clickable");
             this.deactivated_cards.removeClass("clickable");
-            
-            this.deactivated_cards_important = dojo.query(".clickable_important");
-            this.deactivated_cards_important.removeClass("clickable_important");
+
+            this.deactivated_cards_mid_dogma = dojo.query(".mid_dogma");
+            this.deactivated_cards_mid_dogma.removeClass("mid_dogma");
             
             this.off(this.deactivated_cards, 'onclick');
 
@@ -2119,7 +2119,7 @@ function (dojo, declare) {
         
         resurrectClickEvents : function(revert_text) {
             this.deactivated_cards.addClass("clickable");
-            this.deactivated_cards_important.addClass("clickable_important");
+            this.deactivated_cards_mid_dogma.addClass("mid_dogma");
             
             this.restart(this.deactivated_cards, 'onclick');
             
@@ -3549,6 +3549,7 @@ function (dojo, declare) {
                 other_colors.splice(color, 1);
                 var cards = this.selectCardsOnMyBoardOfColors(other_colors);
                 cards.removeClass("clickable");
+                cards.removeClass("mid_dogma");
                 this.off(cards, 'onclick');
                 
                 // Mark info
@@ -3596,6 +3597,7 @@ function (dojo, declare) {
             
             var selectable_cards = this.selectAllCardsOnMyBoard();
             selectable_cards.addClass("clickable");
+            selectable_cards.addClass("mid_dogma");
             this.on(selectable_cards, 'onclick', 'publicationClicForMove');
             
             this.publication_permuted_zone = null;

--- a/innovation.scss
+++ b/innovation.scss
@@ -956,12 +956,12 @@
     &:hover {
         cursor: pointer;
     }
+    &.mid_dogma {
+        box-shadow: 0 0 6px 3px rgb(154, 5, 5) !important;
+    }
 }
 .selected {
-    box-shadow: 0 0 6px 3px rgb(178, 10, 10) !important;
-}
-.clickable_important {
-    box-shadow: 0 0 6px 3px rgb(178, 10, 10) !important;
+    box-shadow: 0 0 6px 3px black !important;
 }
 .splay_indicator {
     margin: auto;


### PR DESCRIPTION
We used to use a red color to signify the "selected" card during the initial phase of the game. I switched that to black, and used red to highlight cards when any player is prompted to click on a card mid-dogma. This should provide a helpful distinction between when players are clicking on a card for the purposes of melding/dogma/etc. vs clicking on a card as a result of on ongoing dogma action (regardless of who initiated it).

<img width="1045" alt="Screen Shot 2022-12-03 at 8 58 38 PM" src="https://user-images.githubusercontent.com/7231485/205470412-ae7705d5-35f3-49dc-9aff-ada0e3136790.png">

<img width="1005" alt="Screen Shot 2022-12-03 at 8 58 49 PM" src="https://user-images.githubusercontent.com/7231485/205470416-6eb4ffae-4e35-44af-ab39-4a42d56c7325.png">

<img width="1223" alt="Screen Shot 2022-12-03 at 8 57 04 PM" src="https://user-images.githubusercontent.com/7231485/205470411-813673aa-d252-4c7d-a25b-29f0eb2cb357.png">
