### PR TITLE
Make it more obvious when an Echoes card is going to be drawn

### DIFF
--- a/innovation.js
+++ b/innovation.js
@@ -1229,7 +1229,12 @@ function (dojo, declare) {
                     
                     // Blue buttons for draw action (or red if taking this action would finish the game)
                     if (args.age_to_draw <= 10) {
-                        this.addActionButton("take_draw_action", _("Draw a ${age}").replace("${age}", this.square('N', 'age', args.age_to_draw)), "action_clicForDraw")
+                        if (args.type_to_draw == 3) {
+                            var draw_button_text = _("Draw an Echoes ${age}");
+                        } else {
+                            var draw_button_text = _("Draw a ${age}");
+                        }
+                        this.addActionButton("take_draw_action", draw_button_text.replace("${age}", this.square('N', 'age', args.age_to_draw)), "action_clicForDraw");
                     }
                     else {
                         this.addActionButton("take_draw_action", _("Finish the game (attempt to draw above ${age_10})").replace('${age_10}', this.square('N', 'age', 10)), "action_clicForDraw")


### PR DESCRIPTION
This was requested in //boardgamearena.com/bug?id=76960.

<img width="689" alt="Screen Shot 2022-12-03 at 9 11 29 PM" src="https://user-images.githubusercontent.com/7231485/205470715-77bab828-704b-4ee6-a6b2-470a7dc14214.png">
<img width="767" alt="Screen Shot 2022-12-03 at 9 11 39 PM" src="https://user-images.githubusercontent.com/7231485/205470716-d06ec6cd-c3d3-419d-9245-67da778b5918.png">
