### PR TITLE
Remove tie_breaker_description and set losers_not_ranked

### DIFF
--- a/gameinfos.inc.php
+++ b/gameinfos.inc.php
@@ -2,112 +2,105 @@
 
 $gameinfos = [
 
-// Game designer (or game designers, separated by commas)
-'designer' => 'Carl Chudyk',       
+    // Game designer (or game designers, separated by commas)
+    'designer' => 'Carl Chudyk',       
 
-// Game artist (or game artists, separated by commas)
-'artist' => 'Cara Judd',         
+    // Game artist (or game artists, separated by commas)
+    'artist' => 'Cara Judd',         
 
-// Year of FIRST publication of this game. Can be negative.
-'year' => 2010,
+    // Year of FIRST publication of this game. Can be negative.
+    'year' => 2010,
 
-// Game publisher
-'publisher' => 'Asmadi Games',
+    // Game publisher
+    'publisher' => 'Asmadi Games',
 
-// Url of game publisher website
-'publisher_website' => 'https://asmadigames.com/',
+    // Url of game publisher website
+    'publisher_website' => 'https://asmadigames.com/',
 
-// Board Game Geek ID of the publisher
-'publisher_bgg_id' => 5407,
+    // Board Game Geek ID of the publisher
+    'publisher_bgg_id' => 5407,
 
-// Board game geek if of the game
-'bgg_id' => 63888,
+    // Board game geek if of the game
+    'bgg_id' => 63888,
 
-// Players configuration that can be played (ex: 2 to 4 players)
-'players' => [2, 3, 4],
+    // Players configuration that can be played (ex: 2 to 4 players)
+    'players' => [2, 3, 4],
 
-// Suggest players to play with this number of players. Must be null if there is no such advice, or if there is only one possible player configuration.
-'suggest_player_number' => null,
+    // Suggest players to play with this number of players. Must be null if there is no such advice, or if there is only one possible player configuration.
+    'suggest_player_number' => null,
 
-// Discourage players to play with these numbers of players. Must be null if there is no such advice.
-'not_recommend_player_number' => null,
+    // Discourage players to play with these numbers of players. Must be null if there is no such advice.
+    'not_recommend_player_number' => null,
 
-// Estimated game duration, in minutes (used only for the launch, afterward the real duration is computed)
-'estimated_duration' => 40,           
+    // Estimated game duration, in minutes (used only for the launch, afterward the real duration is computed)
+    'estimated_duration' => 40,           
 
-// Time in second add to a player when "giveExtraTime" is called (speed profile = fast)
-'fast_additional_time' => 120,           
+    // Time in second add to a player when "giveExtraTime" is called (speed profile = fast)
+    'fast_additional_time' => 120,           
 
-// Time in second add to a player when "giveExtraTime" is called (speed profile = medium)
-'medium_additional_time' => 240,           
+    // Time in second add to a player when "giveExtraTime" is called (speed profile = medium)
+    'medium_additional_time' => 240,           
 
-// Time in second add to a player when "giveExtraTime" is called (speed profile = slow)
-'slow_additional_time' => 480,
+    // Time in second add to a player when "giveExtraTime" is called (speed profile = slow)
+    'slow_additional_time' => 480,
 
-// If you are using a tie breaker in your game (using "player_score_aux"), you must describe here
-// the formula used to compute "player_score_aux". This description will be used as a tooltip to explain
-// the tie breaker to the players.
-// Note: if you are NOT using any tie breaker, leave the empty string.
-//
-// Example: 'tie_breaker_description' => totranslate( "Number of remaining cards in hand" ),
-'tie_breaker_description' => totranslate("Number of achievements if the game ended by score. Else this value is set to zero and is irrelevant: there is no tie breaker."),
+    // The game end result will display "Winner" for the 1st player(s) and "Loser" for all other players
+    'losers_not_ranked' => false,
 
-// Game is "beta". A game MUST set is_beta=1 when published on BGA for the first time, and must remains like this until all bugs are fixed.
-'is_beta' => 1,                     
+    // Game is "beta". A game MUST set is_beta=1 when published on BGA for the first time, and must remains like this until all bugs are fixed.
+    'is_beta' => 1,                     
 
-// Is this game cooperative (all players wins together or loose together)
-'is_coop' => 0, 
+    // Is this game cooperative (all players wins together or loose together)
+    'is_coop' => 0, 
 
+    // Complexity of the game, from 0 (extremely simple) to 5 (extremely complex)
+    'complexity' => 4,    
 
-// Complexity of the game, from 0 (extremely simple) to 5 (extremely complex)
-'complexity' => 4,    
+    // Luck of the game, from 0 (absolutely no luck in this game) to 5 (totally luck driven)
+    'luck' => 2,    
 
-// Luck of the game, from 0 (absolutely no luck in this game) to 5 (totally luck driven)
-'luck' => 2,    
+    // Strategy of the game, from 0 (no strategy can be setup) to 5 (totally based on strategy)
+    'strategy' => 4,    
 
-// Strategy of the game, from 0 (no strategy can be setup) to 5 (totally based on strategy)
-'strategy' => 4,    
+    // Diplomacy of the game, from 0 (no interaction in this game) to 5 (totally based on interaction and discussion between players)
+    'diplomacy' => 3,    
 
-// Diplomacy of the game, from 0 (no interaction in this game) to 5 (totally based on interaction and discussion between players)
-'diplomacy' => 3,    
+    // Games categories
+    //  You can attribute any number of "tags" to your game.
+    //  Each tag has a specific ID (ex: 22 for the category "Prototype", 101 for the tag "Science-fiction theme game")
+    // @see https://en.doc.boardgamearena.com/Game_meta-information:_gameinfos.inc.php#Tags
+    'tags' => [
+        3, // for regular players
+        12, // long game >30m
+        20, // awarded game
+        102, // historical
+        106, // building
+        200, // cards
+        207, // combos
+        208, // area majority
+        209, // race
+        210, // collection
+    ],
 
-
-// Games categories
-//  You can attribute any number of "tags" to your game.
-//  Each tag has a specific ID (ex: 22 for the category "Prototype", 101 for the tag "Science-fiction theme game")
-// @see https://en.doc.boardgamearena.com/Game_meta-information:_gameinfos.inc.php#Tags
-'tags' => [
-    3, // for regular players
-    12, // long game >30m
-    20, // awarded game
-    102, // historical
-    106, // building
-    200, // cards
-    207, // combos
-    208, // area majority
-    209, // race
-    210, // collection
-],
-
-// Favorite colors support
- 'favorite_colors_support' => true,
+    // Favorite colors support
+    'favorite_colors_support' => true,
  
- // Game interface width range (pixels)
-// Note: game interface = space on the left side, without the column on the right
-'game_interface_width' => array(
+    // Game interface width range (pixels)
+    // Note: game interface = space on the left side, without the column on the right
+    'game_interface_width' => array(
 
-    // Minimum width
-    //  default: 740
-    //  maximum possible value: 740 (ie: your game interface should fit with a 740px width (correspond to a 1024px screen)
-    //  minimum possible value: 320 (the lowest value you specify, the better the display is on mobile)
-    'min' => 740,
+        // Minimum width
+        //  default: 740
+        //  maximum possible value: 740 (ie: your game interface should fit with a 740px width (correspond to a 1024px screen)
+        //  minimum possible value: 320 (the lowest value you specify, the better the display is on mobile)
+        'min' => 740,
 
-    // Maximum width
-    //  default: null (ie: no limit, the game interface is as big as the player's screen allows it).
-    //  maximum possible value: unlimited
-    //  minimum possible value: 740
-    'max' => null
-),
+        // Maximum width
+        //  default: null (ie: no limit, the game interface is as big as the player's screen allows it).
+        //  maximum possible value: unlimited
+        //  minimum possible value: 740
+        'max' => null
+    ),
 
     // Game presentation
     // Short game presentation text that will appear on the game description page, structured as an array of paragraphs.


### PR DESCRIPTION
Testing this change together with https://github.com/micahstairs/bga-innovation/pull/808, I got the following screenshots:

<img width="772" alt="Screen Shot 2022-12-09 at 9 39 16 AM" src="https://user-images.githubusercontent.com/7231485/206727766-4728d71b-16e1-42f4-a1e8-746249697b60.png">
<img width="774" alt="Screen Shot 2022-12-09 at 9 41 01 AM" src="https://user-images.githubusercontent.com/7231485/206727773-bf45f842-d889-40cf-9785-e5de7d2e8a88.png">
<img width="772" alt="Screen Shot 2022-12-09 at 9 43 36 AM" src="https://user-images.githubusercontent.com/7231485/206727775-5410ca9d-63c6-4a21-b2bb-4a15618bc167.png">

Relevant bug reports:
- https://boardgamearena.com/bug?id=67958: There is a second and third place awarded when there should only be one winner and the rest losers
- https://boardgamearena.com/bug?id=28575: In a round-robin tournament when END OF GAME BY SCORE, the score difference is messed up
- https://boardgamearena.com/bug?id=76351; lost ELO for 'tying' against my teammate in team game