### PR TITLE
Re-order special achievements

### DIFF
--- a/dbmodel.sql
+++ b/dbmodel.sql
@@ -152,11 +152,11 @@ CREATE TABLE `icon_count` (
 INSERT INTO `card` (`id`, `type`, `location`, `position`) VALUES
 
 /* TODO(LATER): See if we can start indexing the achievements at 0 instead of 10. */
-(105, 0, 'achievements', 10),
-(106, 0, 'achievements', 11),
-(107, 0, 'achievements', 12),
-(108, 0, 'achievements', 13),
-(109, 0, 'achievements', 14),
+(105, 0, 'achievements', 11),
+(106, 0, 'achievements', 10),
+(107, 0, 'achievements', 14),
+(108, 0, 'achievements', 12),
+(109, 0, 'achievements', 13),
 
 /* Cities special achievements */
 (325, 2, 'removed', 15),
@@ -166,11 +166,11 @@ INSERT INTO `card` (`id`, `type`, `location`, `position`) VALUES
 (329, 2, 'removed', 19),
 
 /* Echoes special achievements */
-(435, 3, 'removed', 20),
+(435, 3, 'removed', 22),
 (436, 3, 'removed', 21),
-(437, 3, 'removed', 22),
+(437, 3, 'removed', 24),
 (438, 3, 'removed', 23),
-(439, 3, 'removed', 24);
+(439, 3, 'removed', 20);
 
 /* Insert relic cards */
 

--- a/innovation.js
+++ b/innovation.js
@@ -1404,12 +1404,12 @@ function (dojo, declare) {
 
             // Build popup box
             this.special_achievements_window = new dijit.Dialog({ 'title': _("List of Special Achievements") });
-            var ids = [105, 106, 107, 108, 109];
+            var ids = [106, 105, 107, 109, 108];
             if (this.cities_expansion_enabled) {
                 ids.push(325, 326, 327, 328, 329);
             }
             if (this.echoes_expansion_enabled) {
-                ids.push(435, 436, 437, 438, 439);
+                ids.push(439, 436, 435, 437, 438);
             }
             // TODO(FIGURES): Add special achievements.
             console.log(ids);

--- a/innovation.js
+++ b/innovation.js
@@ -1404,7 +1404,7 @@ function (dojo, declare) {
 
             // Build popup box
             this.special_achievements_window = new dijit.Dialog({ 'title': _("List of Special Achievements") });
-            var ids = [106, 105, 107, 109, 108];
+            var ids = [106, 105, 108, 107, 109];
             if (this.cities_expansion_enabled) {
                 ids.push(325, 326, 327, 328, 329);
             }

--- a/material.inc.php
+++ b/material.inc.php
@@ -540,7 +540,7 @@ $this->textual_card_infos = array(
 
 108 => array('name' => clienttranslate('World'),
     'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have twelve or more ${icon_6} on your board.'),
-    'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_5} Translation.')),
+    'alternative_condition_for_claiming' => clienttranslate('May also be claimed via ${age_3} Translation.')),
 
 109 => array('name' => clienttranslate('Universe'),
     'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you have five top cards, and each is of value ${age_8} or higher.'),


### PR DESCRIPTION
This new order is more intuitive because it's sorted by the age of the "May also be claimed via X" alternate condition.

<img width="1013" alt="Screen Shot 2022-12-09 at 3 55 20 PM" src="https://user-images.githubusercontent.com/7231485/206819406-f8311d42-235f-485e-9274-db24d393153d.png">
<img width="200" alt="Screen Shot 2022-12-09 at 7 37 39 PM" src="https://user-images.githubusercontent.com/7231485/206819408-8f4b9d91-a995-4094-8cad-b994065888fd.png">

While updating this I also found a typo. We were claiming that Translation was an age 5 card, but it's actually an age 3 card.