### PR TITLE
Highlight selected card white instead of black

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -1015,7 +1015,7 @@
 }
 
 .selected {
-  box-shadow: 0 0 6px 3px black !important;
+  box-shadow: 0 0 6px 3px white !important;
 }
 
 .splay_indicator {

--- a/innovation.scss
+++ b/innovation.scss
@@ -971,7 +971,7 @@
     }
 }
 .selected {
-    box-shadow: 0 0 6px 3px black !important;
+    box-shadow: 0 0 6px 3px white !important;
 }
 .splay_indicator {
     margin: auto;


### PR DESCRIPTION
It personally feels a lot better when I click on them now. It's more obvious to me that the card I clicked on is actually selected.

<img width="413" alt="Screen Shot 2022-12-10 at 11 21 33 AM" src="https://user-images.githubusercontent.com/7231485/206864832-d2837cfd-d1dd-467e-96e9-3a7c5b6c0c82.png">

<img width="417" alt="Screen Shot 2022-12-10 at 11 21 25 AM" src="https://user-images.githubusercontent.com/7231485/206864831-2de06052-985f-4ad7-b495-e948a1682fb0.png">
