### PR TITLE
Render special icons on Cities special achievements (#384)

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -1470,7 +1470,7 @@
 .square.in_tooltip.icon_8 {
   background-position-y: -42px;
 }
-.square.in_tooltip.icon_8 {
+.square.in_tooltip.icon_9 {
   background-position-y: -63px;
 }
 .square.in_tooltip.icon_11 {

--- a/innovation.css
+++ b/innovation.css
@@ -1458,6 +1458,40 @@
   background-size: 83px auto;
   background-position-y: -42px;
 }
+.square.in_tooltip.icon_8, .square.in_tooltip.icon_9, .square.in_tooltip.icon_11, .square.in_tooltip.icon_12, .square.in_tooltip.icon_13 {
+  background-image: url("img/cities_special_icons.png");
+  filter: grayscale(1);
+  background-size: 115px auto;
+  width: 20px;
+  height: 20px;
+  top: 4px;
+  position: relative;
+}
+.square.in_tooltip.icon_8 {
+  background-position-y: -42px;
+}
+.square.in_tooltip.icon_8 {
+  background-position-y: -63px;
+}
+.square.in_tooltip.icon_11 {
+  background-position-y: -20px;
+}
+.square.in_tooltip.icon_12 {
+  background-position-y: -20px;
+  transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+}
+.square.in_tooltip.icon_13 {
+  background-position-y: -20px;
+  transform: rotate(90deg);
+  -moz-transform: rotate(90deg);
+  -webkit-transform: rotate(90deg);
+  -o-transform: rotate(90deg);
+  -ms-transform: rotate(90deg);
+}
 .square.in_tooltip.icon_1 {
   background-position-x: 0px;
 }

--- a/innovation.js
+++ b/innovation.js
@@ -1923,7 +1923,7 @@ function (dojo, declare) {
             for (var age = 1; age <= 10; age++) {
                 text = text.replace(new RegExp("\\$\\{age_" + age + "\\}" , "g"), this.square(size, 'age', age));
             }
-            for (var symbol = 0; symbol <= 6; symbol++) {
+            for (var symbol = 0; symbol <= 13; symbol++) {
                 text = text.replace(new RegExp("\\$\\{icon_" + symbol + "\\}" , "g"), this.square(size, 'icon', symbol));
             }
             text = text.replace(new RegExp("\\$\\{music_note\\}" , "g"), this.square(size, 'music', 'note'));
@@ -2853,7 +2853,10 @@ function (dojo, declare) {
             var note_for_monument = _("Note: Transfered cards from other players do not count toward this achievement, nor does exchanging cards from your hand and score pile.");
             var div_condition_for_claiming = "<div><b>" + name + "</b>: " + this.parseForRichedText(_(card_data.condition_for_claiming), 'in_tooltip') + "</div>" + (is_monument ? "<div></br>" + note_for_monument + "</div>" : "");
             
-            var div_alternative_condition_for_claiming = "</br><div>" + this.parseForRichedText(_(card_data.alternative_condition_for_claiming), 'in_tooltip') + "</div>";
+            var div_alternative_condition_for_claiming = "";
+            if (card_data.alternative_condition_for_claiming != null) {
+                div_alternative_condition_for_claiming = "</br><div>" + this.parseForRichedText(_(card_data.alternative_condition_for_claiming), 'in_tooltip') + "</div>";
+            }
             
             return div_condition_for_claiming + div_alternative_condition_for_claiming;            
         },

--- a/innovation.scss
+++ b/innovation.scss
@@ -1321,7 +1321,7 @@
         &.icon_8 {
             background-position-y: -42px;
         }
-        &.icon_8 {
+        &.icon_9 {
             background-position-y: -63px;
         }
         &.icon_11 {

--- a/innovation.scss
+++ b/innovation.scss
@@ -1309,6 +1309,40 @@
             background-size: 83px auto;
             background-position-y: -42px;
         }
+        &.icon_8, &.icon_9, &.icon_11, &.icon_12, &.icon_13 {
+            background-image: url("img/cities_special_icons.png");
+            filter: grayscale(1);
+            background-size: 115px auto;
+            width: 20px;
+            height: 20px;
+            top: 4px;
+            position: relative;
+        }
+        &.icon_8 {
+            background-position-y: -42px;
+        }
+        &.icon_8 {
+            background-position-y: -63px;
+        }
+        &.icon_11 {
+            background-position-y: -20px;
+        }
+        &.icon_12 {
+            background-position-y: -20px;
+            transform: rotate(180deg);
+            -moz-transform: rotate(180deg);
+            -webkit-transform: rotate(180deg);
+            -o-transform: rotate(180deg);
+            -ms-transform: rotate(180deg);
+        }
+        &.icon_13 {
+            background-position-y: -20px;
+            transform: rotate(90deg);
+            -moz-transform: rotate(90deg);
+            -webkit-transform: rotate(90deg);
+            -o-transform: rotate(90deg);
+            -ms-transform: rotate(90deg);
+        }
         @include m.generate-icon-x-position(1, 6, 0, 14px);
     }
 }

--- a/material.inc.php
+++ b/material.inc.php
@@ -1185,23 +1185,23 @@ $this->textual_card_infos = array(
 /* Cities Special achievements */
 
 325 => array('name' => clienttranslate('Legend'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you meld a city with a ${left_arrow} on a color already splayed left.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you meld a city with a ${icon_11} on a color already splayed left.'),
 ),
 
 326 => array('name' => clienttranslate('Repute'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you meld a city with a ${right_arrow} on a color already splayed right.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you meld a city with a ${icon_12} on a color already splayed right.'),
 ),
 
 327 => array('name' => clienttranslate('Fame'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you meld a city with a ${up_arrow} on a color already splayed up.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you meld a city with a ${icon_13} on a color already splayed up.'),
 ),
 
 328 => array('name' => clienttranslate('Glory'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you tuck a city with a ${flag}.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you tuck a city with a ${icon_8}.'),
 ),
 
 329 => array('name' => clienttranslate('Victory'),
-    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you tuck a city with a ${fountain}.'),
+    'condition_for_claiming' => clienttranslate('Claim this special achievement ${immediately} if you tuck a city with a ${icon_9}.'),
 ),
     
 /* Echoes - Age 1 */


### PR DESCRIPTION
<img width="930" alt="Screen Shot 2022-12-26 at 5 06 34 PM" src="https://user-images.githubusercontent.com/7231485/209585882-8873a7fa-dae5-4af1-81ae-5ba0101b9b6d.png">
<img width="636" alt="Screen Shot 2022-12-26 at 5 08 35 PM" src="https://user-images.githubusercontent.com/7231485/209585883-3796a77b-5ae8-4314-93d0-d7b9f912f921.png">

Instead of adding in new brown images like we see on the real cards, I just decided to use a grayscale version of one of the colored icons. It does the trick!

This closes #384.