### PR TITLE
Fix endorsement of Stethoscope (#632)

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -13847,6 +13847,10 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
             // id 386, Echoes age 6: Stethoscope
             case "386E1":
+                // Only reset the auxiliary value if the echo effect is not being repeated for a second time
+                if (!self::getGameStateValue('endorse_action_state') == 3) {
+                    self::setIndexedAuxiliaryValue($player_id, -1);
+                }
                 $step_max = 1;
                 break;
 
@@ -23903,8 +23907,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                     }
                     if ($n > 0 && self::getGameStateValue('color_last_selected') == 0) {
                         self::setIndexedAuxiliaryValue($player_id, 1); // it is blue
-                    } else {
-                        self::setIndexedAuxiliaryValue($player_id, -1);
                     }
                     break;
 


### PR DESCRIPTION
This card now behaves correctly if a yellow card is melded after a blue card.

<img width="246" alt="Screen Shot 2023-01-09 at 2 30 25 PM" src="https://user-images.githubusercontent.com/7231485/211392309-e032df7c-1eb4-4419-a679-c90ffe88024b.png">

