### PR TITLE
Fix endorsement of Democracy (#632)

### DIFF
--- a/dbmodel.sql
+++ b/dbmodel.sql
@@ -32,6 +32,7 @@ ALTER TABLE `player` ADD `number_of_scored_cards` TINYINT UNSIGNED NOT NULL DEFA
 ALTER TABLE `player` ADD `pile_display_mode` BOOLEAN DEFAULT TRUE COMMENT 'Player preference for how stacks on the board are displayed, TRUE for expanded, FALSE for compact';
 ALTER TABLE `player` ADD `pile_view_full` BOOLEAN DEFAULT FALSE COMMENT 'Player preference for whether to show all cards in a stack on the board, TRUE if yes, FALSE if no';
 ALTER TABLE `player` ADD `effects_had_impact` BOOLEAN DEFAULT FALSE COMMENT 'Indicate if the player has changed the situation (TRUE) or not (FALSE) in the game when it was his turn to play within a dogma effect';
+ALTER TABLE `player` ADD `democracy_counter` TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Number of cards that this player has returned so far during this action via Democracy';
 
 /* Main table to store all the cards of the game and their characteristics. See the material file to see the textual info */
 CREATE TABLE IF NOT EXISTS `card` (


### PR DESCRIPTION
It wasn't possible to use existing auxiliary variables since those are all scoped to a specific execution of a card, and this needs to be scoped to the entire action. It wasn't possible (without very complicated encoding) to use a global variable since each player needs its own counters. So the simplest solution here is to add a column to the player table to keep track of this counter (resetting it to 0 at the end of each action).

I tested this by endorsing Democracy, but this should always work fine in the very unlikely case that the card gets executed twice due to nested execution in the same action.

<img width="245" alt="Screenshot 2023-01-11 at 2 41 39 PM" src="https://user-images.githubusercontent.com/7231485/211902461-096edda8-5f14-4510-9ecb-5113993f2ea4.png">
