### PR TITLE
Make the layout responsive and configurable

### DIFF
--- a/gameoptions.inc.php
+++ b/gameoptions.inc.php
@@ -158,6 +158,16 @@ $game_options = array(
 );
 
 $game_preferences = array(
+    112 => array(
+        'name' => totranslate('Position of decks and achievements'),
+        'needReload' => true,
+        'values' => array(
+            1 => array('name' => totranslate('Automatic')),
+            2 => array('name' => totranslate('Right')),
+            3 => array('name' => totranslate('Bottom')),
+        ),
+        'default' => 1,
+    ),
     100 => array(
         'name' => totranslate('Dogma confirmation'),
         'needReload' => true,

--- a/innovation.css
+++ b/innovation.css
@@ -250,38 +250,6 @@
   display: inline-block;
   position: relative;
   background-color: unset;
-  width: 140px;
-}
-@media (min-width: 768px) {
-  .achievement_container {
-    width: 175px;
-  }
-}
-@media (min-width: 992px) {
-  .achievement_container.to_win_4 {
-    width: 140px;
-  }
-  .achievement_container.to_win_5 {
-    width: 175px;
-  }
-  .achievement_container.to_win_6 {
-    width: 210px;
-  }
-  .achievement_container.to_win_7 {
-    width: 245px;
-  }
-  .achievement_container.to_win_8 {
-    width: 280px;
-  }
-  .achievement_container.to_win_9 {
-    width: 315px;
-  }
-  .achievement_container.to_win_10 {
-    width: 350px;
-  }
-  .achievement_container.to_win_11 {
-    width: 385px;
-  }
 }
 .achievement_container > p {
   font-style: italic;
@@ -349,6 +317,7 @@
 }
 .reference_card.S {
   width: 96px;
+  min-width: 96px;
   height: 69px;
   background-size: 100px auto;
   background-position: -2px -145px;

--- a/innovation.scss
+++ b/innovation.scss
@@ -238,13 +238,6 @@
     display: inline-block;
     position: relative;
     background-color: unset;
-    width: (v.$recto-S-width + v.$achievment-container-recto-S-width-Buffer) * 4;
-	@media (min-width: v.$width_tablet) {
-		width: (v.$recto-S-width + v.$achievment-container-recto-S-width-Buffer) * 5;
-	}
-	@media (min-width: v.$width_desktop) {
-		@include m.generate_achievement_container_widths(4,11)
-	}
     >p {
         font-style: italic;
         font-size: 0.8em;
@@ -305,6 +298,7 @@
     }
     &.S {
         width: 96px;
+        min-width: 96px;
         height: 69px;
         background-size: 100px auto;
         background-position: -2px -145px;

--- a/innovation_innovation.tpl
+++ b/innovation_innovation.tpl
@@ -86,17 +86,19 @@
             <!-- END decks_group_5 -->
         </div>
     </div>
-    <div id="available_relics_container">
-        <p class="text_center"><!-- BEGIN available_relics -->{AVAILABLE_RELICS}<!-- END available_relics --></p>
-        <div id="relics"></div>
-    </div>
-    <div id="available_achievements_container">
-        <p class="text_center"><!-- BEGIN available_achievements -->{AVAILABLE_ACHIEVEMENTS}<!-- END available_achievements --></p>
-        <div id="achievements"></div>
-    </div>
-    <div id="available_special_achievements_container">
-        <p class="text_center"><!-- BEGIN special_achievements -->{SPECIAL_ACHIEVEMENTS}<!-- END special_achievements --></p>
-        <div id="special_achievements"></div>
+    <div id="available_relics_and_achievements_container">
+        <div id="available_relics_container">
+            <p class="text_center"><!-- BEGIN available_relics -->{AVAILABLE_RELICS}<!-- END available_relics --></p>
+            <div id="relics"></div>
+        </div>
+        <div id="available_achievements_container">
+            <p class="text_center"><!-- BEGIN available_achievements -->{AVAILABLE_ACHIEVEMENTS}<!-- END available_achievements --></p>
+            <div id="achievements"></div>
+        </div>
+        <div id="available_special_achievements_container">
+            <p class="text_center"><!-- BEGIN special_achievements -->{SPECIAL_ACHIEVEMENTS}<!-- END special_achievements --></p>
+            <div id="special_achievements"></div>
+        </div>
     </div>
 </div>
 

--- a/misc/_mixins.scss
+++ b/misc/_mixins.scss
@@ -1,15 +1,5 @@
 @use "variables" as v;
 @use 'sass:math';
-@mixin achievement-win-number($number) {
-	&.to_win_#{$number} {
-		width: (v.$recto-S-width + v.$achievment-container-recto-S-width-Buffer) * $number;
-	}
-}
-@mixin generate_achievement_container_widths ($min, $max) {
-	@for $i from $min through $max {
-		@include achievement-win-number($i)
-	}
-}
 @mixin class-variable-position ($className, $number, $position, $axis) {
     &.#{$className}_#{$number} {
         background-position-#{$axis}: -$position;

--- a/misc/_variables.scss
+++ b/misc/_variables.scss
@@ -1,5 +1,3 @@
-$width_desktop: 992px;
-$width_tablet: 768px;
 $recto-S-width: 31px;
 $recto-S-height: 45px;
 $achievment-container-recto-S-width-Buffer: 4px;


### PR DESCRIPTION
Players can now choose whether to put the decks and achievements on the right side or on the bottom (the default is to automatically pick based on screen size).

<img width="856" alt="Screenshot 2023-01-24 at 7 17 21 PM" src="https://user-images.githubusercontent.com/7231485/214451113-4d539e8f-f944-4b35-b29f-df69f435cb9a.png">
<img width="873" alt="Screenshot 2023-01-24 at 7 17 43 PM" src="https://user-images.githubusercontent.com/7231485/214451118-a3bab88b-d948-40dc-8fc6-da496248f743.png">

Before (mobile):
![Screenshot_20230121-235617](https://user-images.githubusercontent.com/7231485/214451469-7fa6cc3f-f3ef-4e31-984c-5a6dbb4511f4.png)

After (mobile):
![Screenshot_20230122-003852](https://user-images.githubusercontent.com/7231485/214451536-47eb10e7-17e9-45ce-82fb-be9fe8f0c2e1.png)

