### PR TITLE
Fix mobile layout issue when decks/achievements are on right

### DIFF
--- a/innovation.js
+++ b/innovation.js
@@ -907,6 +907,7 @@ function (dojo, declare) {
             } else {
                 var main_area_width = window_width - player_panel_width;
             }
+            dojo.style('main_area', 'width', main_area_width + 'px');
 
             if (decks_on_right) {
                 dojo.style('main_area_wrapper', 'flex-direction', 'row');


### PR DESCRIPTION
Before:
![Screenshot_20230205-172720](https://user-images.githubusercontent.com/7231485/216849716-3cdaecfc-ce0d-4cc1-ba9e-4e8d3201d885.png)

After:
![Screenshot_20230205-172650](https://user-images.githubusercontent.com/7231485/216849722-d950a488-b88c-47c1-8129-a73ec1ffad00.png)
