### PR TITLE
Fix bug when location_to=none (https://boardgamearena.com/bug?id=81808)

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -9354,7 +9354,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
         if ($splay_direction == -1) {
             $player_id_is_owner_from = $owner_from == $player_id;
-            $player_id_is_owner_to = $owner_to == $player_id || $location_to == 'none';
+            $player_id_is_owner_to = $owner_to == $player_id;
         }
         
         // Identification of the potential opponent(s)
@@ -9432,7 +9432,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         }
         
         // Creation of the message
-        if ($opponent_name === null || $opponent_id == -2 || $opponent_id == -3 || $opponent_id == -4) {
+        if ($opponent_name === null || $opponent_id == -2 || $opponent_id == -3 || $opponent_id == -4 || $location_to == 'none') {
             if ($splay_direction == -1) {
                 $messages = self::getTransferInfoWithOnePlayerInvolved($location_from, $location_to, $player_id_is_owner_from, $bottom_from, $bottom_to, $you_must, $player_must, $player_name, $number, $cards, $opponent_name, $code);
                 $splay_direction = null;

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -9354,7 +9354,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
         if ($splay_direction == -1) {
             $player_id_is_owner_from = $owner_from == $player_id;
-            $player_id_is_owner_to = $owner_to == $player_id;
+            $player_id_is_owner_to = $owner_to == $player_id || $location_to == 'none';
         }
         
         // Identification of the potential opponent(s)
@@ -17475,7 +17475,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 
                 'owner_from' => $player_id,
                 'location_from' => 'board',
-                'owner_to' => $player_id,
                 'location_to' => 'none'
             );
             break;
@@ -19443,7 +19442,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
                 'owner_from' => $player_id,
                 'location_from' => 'hand',
-                'owner_to' => $player_id,
                 'location_to' => 'none',
             );       
             break;
@@ -19467,7 +19465,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
 
                 'owner_from' => $player_id,
                 'location_from' => 'hand',
-                'owner_to' => $player_id,
                 'location_to' => 'none',
             );       
             break;


### PR DESCRIPTION
When `location_to = "none"`, that means that the player is just choosing a card and it's not actually being moved everywhere. So all of these cases should be handled by getTransferInfoWithOnePlayerInvolved (not getTransferInfoWithTwoPlayersInvolved), otherwise an error gets thrown (this error only actually surfaces in certain situations when the effect is shared - it's the result of a stale `owner_to` value).