### PR TITLE
Fix size of City titles on .L cards (#945)

### DIFF
--- a/innovation.css
+++ b/innovation.css
@@ -896,9 +896,9 @@
   height: 37px;
 }
 .card_title.L.type_2 {
-  left: 190px;
+  left: 126px;
   top: 142px;
-  width: 80px;
+  width: 210px;
 }
 
 .i_demand, .i_compel, .immediately, .possible_action, .equal, .more, .less, .name_in_tooltip, .warning {
@@ -1042,23 +1042,23 @@
   box-shadow: 0px 0px 6px 2px #fff;
 }
 .current_effect.light {
-  background-color: white !important;
+  background-color: rgb(255, 255, 255) !important;
 }
 .current_effect.dark {
-  background-color: black !important;
+  background-color: rgb(0, 0, 0) !important;
 }
 
 .clickable {
-  box-shadow: 0 0 6px 3px #1b059a !important;
+  box-shadow: 0 0 6px 3px rgb(27, 5, 154) !important;
 }
 .clickable:hover {
   cursor: pointer;
 }
 .clickable.mid_dogma {
-  box-shadow: 0 0 6px 3px #9a0505 !important;
+  box-shadow: 0 0 6px 3px rgb(154, 5, 5) !important;
 }
 .clickable.can_endorse {
-  box-shadow: 0 0 6px 3px #fc00b8 !important;
+  box-shadow: 0 0 6px 3px rgb(252, 0, 184) !important;
 }
 
 .selected {

--- a/innovation.scss
+++ b/innovation.scss
@@ -872,9 +872,9 @@
         width: 230px;
         height: 37px;
         &.type_2 {
-            left: 190px;
+            left: 126px;
             top: 142px;
-            width: 80px;
+            width: 210px;
         }
     }
 }


### PR DESCRIPTION
<img width="1036" alt="Screen Shot 2023-02-20 at 8 36 40 PM" src="https://user-images.githubusercontent.com/7231485/220225840-6c6657fa-5456-46b9-ba14-6ef8e5e91b92.png">

Ignore the other diffs. I just installed SASS on a new computer and it seemed to want the color codes in RGB instead of using constants.
