### PR TITLE
Implement new distance rule for dogma (#963)

### DIFF
--- a/innovation.action.php
+++ b/innovation.action.php
@@ -273,7 +273,7 @@
         
         // Retrieve arguments
         $card_id = self::getArg("card_id", AT_posint, true);
-        $card_id_to_return = self::getArg("card_id", AT_posint, false, null);
+        $card_id_to_return = self::getArg("card_id_to_return", AT_posint, false, null);
         
         // Call dogma from game logic
         $this->game->dogma($card_id, $card_id_to_return);

--- a/innovation.game.php
+++ b/innovation.game.php
@@ -3128,6 +3128,9 @@ class Innovation extends Table
         if (!$this->innovationGameState->usingFourthEditionRules()) {
             return [];
         }
+        if (self::decodeGameType($this->innovationGameState->get('game_type')) == 'team') {
+            return [];
+        }
         $player_ids = self::getActivePlayerIdsInTurnOrderStartingWithCurrentPlayer();
         if (count($player_ids) <= 3) {
             return [];
@@ -7570,13 +7573,36 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         self::checkAction('dogma');
         $player_id = self::getActivePlayerId();
         
-        // Check if the player has this card really on his board
         $card = self::getCardInfo($card_id);
-        
-        // Player does not have this card on their board
-        if ($card['owner'] != $player_id || $card['location'] != "board") {
-            self::throwInvalidChoiceException();
+
+        $card_to_return = null;
+        if ($card_id_to_return === null) {
+            if ($card['owner'] != $player_id) {
+                self::throwInvalidChoiceException();
+            }
+        } else {
+
+            $card_to_return = self::getCardInfo($card_id_to_return);
+
+            // The distance rule is only in effect when using the 4th edition
+            if (!$this->innovationGameState->usingFourthEditionRules()) {
+                self::throwInvalidChoiceException();
+            }
+            if ($card_to_return['owner'] != $player_id || $card_to_return['location'] != 'hand') {
+                self::throwInvalidChoiceException();
+            }
+            $found_owner = false;
+            foreach (self::getPlayerIdsAffectedByDistanceRule() as $opponent_id) {
+                if ($card['owner'] == $opponent_id) {
+                    $found_owner = true;
+                    break;
+                }
+            }
+            if (!$found_owner) {
+                self::throwInvalidChoiceException();
+            }
         }
+        
         // Card is not at the top of a stack
         if (!self::isTopBoardCard($card)) {
             self::throwInvalidChoiceException();
@@ -7593,7 +7619,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
             self::incStat(1, 'dogma_actions_number_targeting_artifact_on_board', $player_id);
         }
 
-        self::setUpDogma($player_id, $card);
+        self::setUpDogma($player_id, $card, /*extra_icons_from_artifact_on_display=*/ 0, /*card_to_tuck=*/ null, $card_to_return);
 
         // Resolve the first dogma effect of the card
         self::trace('playerTurn->dogmaEffect (dogma)');
@@ -7696,9 +7722,18 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
         ));
     }
     
-    function setUpDogma($player_id, $card, $extra_icons_from_artifact_on_display = 0, $card_to_tuck = null) {
+    function setUpDogma($player_id, $card, $extra_icons_from_artifact_on_display = 0, $card_to_tuck = null, $card_to_return = null) {
 
         self::notifyDogma($card);
+
+        if ($card_to_return != null) {
+            try {
+                self::returnCard($card_to_return, $player_id);
+            } catch (EndOfGame $e) {
+                self::trace('EOG bubbled from self::setUpDogma');
+                throw $e; // Re-throw exception to higher level
+            }
+        }
 
         if ($card_to_tuck != null) {
             try {

--- a/innovation.js
+++ b/innovation.js
@@ -2116,7 +2116,6 @@ function (dojo, declare) {
         addTooltipsWithActionsToBoard : function(cards, dogma_effect_info) {
             this.addTooltipsWithActionsTo(cards, this.createActionTextForDogma, dogma_effect_info, 'board');
             var self = this;
-            console.log(dogma_effect_info);
             cards.forEach(function(card) {
                 var HTML_id = dojo.attr(card, "id");
                 var id = self.getCardIdFromHTMLId(HTML_id);
@@ -3973,7 +3972,7 @@ function (dojo, declare) {
         },
         
         action_clickDogma : function(event_or_html_id, via_alternate_prompt=null, card_id_to_return=null) {
-            if (via_alternate_prompt != 'endorse') {
+            if (via_alternate_prompt == null) {
                 this.stopActionTimer();
                 this.deactivateClickEvents();
             }
@@ -4100,10 +4099,9 @@ function (dojo, declare) {
                 card_id: card_id,
             };
             var card_id_to_return = dojo.attr(HTML_id, 'card_id_to_return');
-            if (card_id_to_return != null) {
-                payload["card_id_to_return"] = card_id_to_return;
+            if (card_id_to_return != "null") {
+                payload["card_id_to_return"] = parseInt(card_id_to_return);
             }
-            console.log(payload);
             this.ajaxcall("/innovation/innovation/dogma.html",
                 payload,
                 this,
@@ -4133,16 +4131,13 @@ function (dojo, declare) {
             cards_to_return.forEach(function(node) {
                 dojo.attr(node, 'card_to_dogma_html_id', HTML_id);
             });
+            this.addTooltipsWithoutActionsToMyHand();
         },
 
         action_cancelNonAdjacentDogma : function(event) {
             this.resurrectClickEvents(true);
             dojo.destroy("non_adjacent_dogma_cancel_button");
             dojo.destroy("non_adjacent_dogma_button");
-            var cards_in_hand = this.selectMyCardsInHand();
-            cards_in_hand.removeClass("mid_dogma");
-            this.off(cards_in_hand, 'onclick');
-            this.on(cards_in_hand, 'onclick', 'action_clickMeld');
         },
 
         action_confirmNonAdjacentDogma : function(event) {


### PR DESCRIPTION
In 4th edition games with 4 or more players (excluding team games), players can return a card from their hand in exchange for dogma'ing a top card from a non-adjacent's player's board.

I also added a feature to debug mode, which automatically choose arbitrary initial cards for other players (speeds up manual testing for 4-5 player games significantly).