### PR TITLE
Fix Tools bug which prevented less than 3 cards from being returned

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -62,6 +62,7 @@ class Innovation extends Table
             'can_pass' => 28,
             'n_min' => 29,
             'n_max' => 30,
+            // TODO(LATER): Deprecate and remove 'solid_constraint'.
             'solid_constraint' => 31,
             'splay_direction' => 32,
             'owner_from' => 33,
@@ -15184,7 +15185,6 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
             $options = array(
                 'player_id' => $player_id,
                 'n' => 3,
-                'solid_constraint' => true, // The player MUST have three cards in hand to trigger the effect
                 'can_pass' => true,
                 
                 'owner_from' => $player_id,
@@ -22115,7 +22115,7 @@ function getOwnersOfTopCardWithColorAndAge($color, $age) {
                 
                 // id 1, age 1: Tools
                 case "1N1A":
-                    if ($n > 0) { // "If you do"
+                    if ($n == 3) { // "If you do"
                         self::executeDrawAndMeld($player_id, 3); // "Draw and meld a 3"
                     }
                     break;


### PR DESCRIPTION
This was reported in https://forum.boardgamearena.com/viewtopic.php?t=29952 (which links to https://boardgamegeek.com/thread/1579258/article/22748217). The BGG thread doesn't have an official ruling from Carl/Chris, but I believe this ruling is solid. We can compare it to cards like Reformation where if you have 8 leaves but less than 4 cards in hand, you still get the opportunity to tuck the cards in your hand ("do as much as you can" rule).