### PR TITLE
#93956: "Jackalope did not allow me to choose the color to unsplay"

### DIFF
--- a/modules/Innovation/Cards/Unseen/Card561.php
+++ b/modules/Innovation/Cards/Unseen/Card561.php
@@ -53,8 +53,11 @@ class Card561 extends Card
     $colors = [];
     for ($color = 0; $color < 5; $color++) {
       $numVisibleCards = $this->game->countVisibleCards(self::getPlayerId(), $color);
-      if ($numVisibleCards == $mostVisibleCards) {
+      if ($numVisibleCards > 1 && $numVisibleCards > $mostVisibleCards) {
         $colors = [$color];
+      }
+      if ($numVisibleCards == $mostVisibleCards) {
+        $colors[] = $color;
       }
     }
     return $colors;

--- a/modules/Innovation/Cards/Unseen/Card561.php
+++ b/modules/Innovation/Cards/Unseen/Card561.php
@@ -53,10 +53,9 @@ class Card561 extends Card
     $colors = [];
     for ($color = 0; $color < 5; $color++) {
       $numVisibleCards = $this->game->countVisibleCards(self::getPlayerId(), $color);
-      if ($numVisibleCards > 1 && $numVisibleCards > $mostVisibleCards) {
-        $colors = [$color];
-      }
-      if ($numVisibleCards == $mostVisibleCards) {
+      // TODO(LATER): Move this optimization to a more central place (if no color has more than
+      // one card, then the unsplay is a no-op).
+      if ($numVisibleCards > 1 && $numVisibleCards === $mostVisibleCards) {
         $colors[] = $color;
       }
     }


### PR DESCRIPTION
Changed the getColorsWithMostVisibleCards function to check if card are splayed otherwise during sharing the player is prompted to unsplay colors not splayed when there are two pile the same. Secondly if more than 1 color has the same number of visible cards add to the array instead of replacing the array.