### PR TITLE
Crossword(#413) Bug#99413

### DIFF
--- a/modules/Innovation/Cards/Echoes/Card413.php
+++ b/modules/Innovation/Cards/Echoes/Card413.php
@@ -59,7 +59,7 @@ class Card413 extends AbstractCard
     if (count($remainingValues) > 0) {
       self::setAuxiliaryArray($remainingValues);
       self::setNextStep(1);
-    } else if (self::isFourthEdition()) {
+    } else if (self::wasForeseen()) {
       foreach (self::getActionScopedAuxiliaryArray() as $cardId) {
         $this->game->transferCardFromTo(self::getCard($cardId), 0, 'achievements');
       }


### PR DESCRIPTION
Crossword would execute the 'if foreseen' effect even on regular dogmas. This was solved by adding a missing 'ifForeseen()' conditional.