### PR TITLE
Map Locations::AVAILABLE_ACHIEVEMENTS to Locations::ACHIEVEMENTS

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -4368,6 +4368,11 @@ class Innovation extends Table
         $type_condition = $type === null ? "" : self::format("type = {type} AND", array('type' => $type));
         $is_relic_condition = $is_relic === null ? "" : self::format("is_relic = {is_relic} AND", array('is_relic' => ($is_relic ? 'TRUE' : 'FALSE')));
 
+        if ($location == Locations::AVAILABLE_ACHIEVEMENTS) {
+            $location = Locations::ACHIEVEMENTS;
+            $owner = 0;
+        }
+
         if ($owner == -2) { // any player
             $owner_condition = "owner != 0 AND";
         } else if ($owner == -3) { // any opponent


### PR DESCRIPTION
Several cards (366, 385 482) were bugged due to failed getCards() calls that referenced a Locations::AVAILABLE_ACHIEVEMENTS const that did not get mapped back to Locations::ACHIEVEMENTS (owner = 0). In the getOrCountCardsInLocation() function, this mapping is now being done, which fixes these bugs. 