### PR TITLE
#102497: "Generated notifications are larger than 128k"

### DIFF
--- a/innovation.game.php
+++ b/innovation.game.php
@@ -59,6 +59,24 @@ class Innovation extends Table
     const COMPEL_EFFECT = 2;
     const ECHO_EFFECT = 3;
 
+    static function stripTransferInfoForNotification(array $transferInfo): array {
+        // dereference transferInfo
+        $transferInfo = (array) $transferInfo;
+        unset($transferInfo['splay_direction_from']);
+        unset($transferInfo['bottom_from']);
+        unset($transferInfo['bottom_to']);
+        unset($transferInfo['score_keyword']);
+        unset($transferInfo['meld_keyword']);
+        unset($transferInfo['achieve_keyword']);
+        unset($transferInfo['draw_keyword']);
+        unset($transferInfo['safeguard_keyword']);
+        unset($transferInfo['return_keyword']);
+        unset($transferInfo['foreshadow_keyword']);
+        //unset($transferInfo['player_id']);
+        //unset($transferInfo['opponent_id']);
+        return $transferInfo;
+    }
+
     function __construct()
     {
         // Your global variables labels:
@@ -2416,6 +2434,7 @@ class Innovation extends Table
                 throw new BgaVisibleSystemException(self::format(self::_("Unhandled case in {function}: '{code}'"), array('function' => 'notifyWithNoPlayersInvolved()', 'code' => $location_from . '->' . $location_to)));
         }
 
+        $transferInfo = self::stripTransferInfoForNotification($transferInfo);
         $info = array_merge($transferInfo, $progressInfo);
 
         $notif_args = array_merge($info, self::getDelimiterMeanings($message, $card['id']));
@@ -2715,13 +2734,15 @@ class Innovation extends Table
             }
         }
 
+        $player_id = $transferInfo['player_id'];
+        $transferInfo = self::stripTransferInfoForNotification($transferInfo);
         $info = array_merge($transferInfo, $progressInfo);
         $delimiters_for_player = self::getDelimiterMeanings($message_for_player, $card['id']);
         $notif_args_for_player = array_merge($notif_args_for_player, $info, $delimiters_for_player);
         $delimiters_for_others = self::getDelimiterMeanings($message_for_others, $card['id']);
         $notif_args_for_others = array_merge($notif_args_for_others, $info, $delimiters_for_others);
-        self::notifyPlayer($transferInfo['player_id'], "transferedCard", $message_for_player, $notif_args_for_player);
-        self::notifyAllPlayersBut($transferInfo['player_id'], "transferedCard", $message_for_others, $notif_args_for_others);
+        self::notifyPlayer($player_id, "transferedCard", $message_for_player, $notif_args_for_player);
+        self::notifyAllPlayersBut($player_id, "transferedCard", $message_for_others, $notif_args_for_others);
     }
 
     function getTransferInfoWithOnePlayerInvolved($owner_from, $location_from, $location_to, $player_id_is_owner_from, $player_id_is_owner_to, $bottom_from, $bottom_to, $score_keyword, $meld_keyword, $achieve_keyword, $you_must, $player_must, $player_name, $number, $cards, $targetable_players, $code)
@@ -3246,15 +3267,18 @@ class Innovation extends Table
             $notif_args_for_others['is_relic'] = $card['is_relic'];
         }
 
+        $player_id = $transferInfo['player_id'];
+        $opponent_id = $transferInfo['opponent_id'];
+        $transferInfo = self::stripTransferInfoForNotification($transferInfo);
         $info = array_merge($transferInfo, $progressInfo);
         $notif_args_for_player = array_merge($notif_args_for_player, $info, self::getDelimiterMeanings($message_for_player, $card['id']));
         $notif_args_for_opponent = array_merge($notif_args_for_opponent, $info, self::getDelimiterMeanings($message_for_opponent, $card['id']));
         $notif_args_for_others = array_merge($notif_args_for_others, $info, self::getDelimiterMeanings($message_for_others, $card['id']));
 
 
-        self::notifyPlayer($transferInfo['player_id'], "transferedCard", $message_for_player, $notif_args_for_player);
-        self::notifyPlayer($transferInfo['opponent_id'], "transferedCard", $message_for_opponent, $notif_args_for_opponent);
-        self::notifyAllPlayersBut(array($transferInfo['player_id'], $transferInfo['opponent_id']), "transferedCard", $message_for_others, $notif_args_for_others);
+        self::notifyPlayer($player_id, "transferedCard", $message_for_player, $notif_args_for_player);
+        self::notifyPlayer($opponent_id, "transferedCard", $message_for_opponent, $notif_args_for_opponent);
+        self::notifyAllPlayersBut(array($player_id, $opponent_id), "transferedCard", $message_for_others, $notif_args_for_others);
     }
 
     function getTransferInfoWithTwoPlayersInvolved($location_from, $location_to, $player_id_is_owner_from, $player_id_is_owner_to, $opponent_id_is_owner_from, $opponent_id_is_owner_to, $bottom_from, $bottom_to, $score_keyword, $meld_keyword, $you_must, $player_must, $your, $player_name, $opponent_name, $number, $cards)

--- a/modules/Innovation/Cards/Artifacts/Card133.php
+++ b/modules/Innovation/Cards/Artifacts/Card133.php
@@ -4,7 +4,6 @@ namespace Innovation\Cards\Artifacts;
 
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\CardTypes;
-use Innovation\Enums\Locations;
 
 class Card133 extends AbstractCard
 {

--- a/modules/Innovation/Cards/Artifacts/Card193.php
+++ b/modules/Innovation/Cards/Artifacts/Card193.php
@@ -18,11 +18,7 @@ class Card193 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return [
-      'location_from' => Locations::HAND,
-      'meld_keyword'  => true,
-      'age'           => 8,
-    ];
+    return self::youMust()->meld()->value(8)->fromYourHand()->build();
   }
 
   public function handleCardChoice(array $card)

--- a/modules/Innovation/Cards/Artifacts/Card194.php
+++ b/modules/Innovation/Cards/Artifacts/Card194.php
@@ -36,7 +36,7 @@ class Card194 extends AbstractCard
             self::achieve($card, $playerId);
           } else {
             self::transferToHand($card);
-            self::achieve(self::getTopCardOfColor($color), $playerId);
+            self::achieve(self::getTopCardOfColor($color, $playerId), $playerId);
           }
         } else {
           self::transferToHand($card);

--- a/modules/Innovation/Cards/Artifacts/Card197_3E.php
+++ b/modules/Innovation/Cards/Artifacts/Card197_3E.php
@@ -26,7 +26,7 @@ class Card197_3E extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return self::youMust()->all()->fromMyBoard()->toYourScore()->withDemandEffect()->build();
+    return self::youMust()->all()->fromYourBoard()->toMyScore()->withDemandEffect()->build();
   }
 
   public function compelMightBeEffective(): bool

--- a/modules/Innovation/Cards/Artifacts/Card211.php
+++ b/modules/Innovation/Cards/Artifacts/Card211.php
@@ -35,7 +35,7 @@ class Card211 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return self::youMay()->score()->withColor(Colors::YELLOW)->fromBottom()->fromMyBoard()->build();
+      return self::youMay()->score()->withColor(Colors::YELLOW)->fromBottom()->fromYourBoard()->build();
     } else if (self::isSecondInteraction()) {
       return self::youMay()->choose([1])->build();
     } else {

--- a/modules/Innovation/Cards/Artifacts/Card456.php
+++ b/modules/Innovation/Cards/Artifacts/Card456.php
@@ -20,7 +20,7 @@ class Card456 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return self::youMust()->meld()->onlyCardsInAuxiliaryArray()->fromMyHand()->build();
+    return self::youMust()->meld()->onlyCardsInAuxiliaryArray()->fromYourHand()->build();
   }
 
   public function handleCardChoice(array $card)

--- a/modules/Innovation/Cards/Artifacts/Card457.php
+++ b/modules/Innovation/Cards/Artifacts/Card457.php
@@ -29,7 +29,7 @@ class Card457 extends AbstractCard
       }
       return self::youMust()->chooseCardFrom(Locations::BOARD)->fromAnyPlayer()->withColor(self::getLastSelectedColor())->build();
     } else {
-      return self::youMay()->return()->exactly(2)->fromMyHand()->build();
+      return self::youMay()->return()->exactly(2)->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Base/Card48.php
+++ b/modules/Innovation/Cards/Base/Card48.php
@@ -24,7 +24,7 @@ class Card48 extends AbstractCard
   public function initialExecution()
   {
     if (self::isDemand() || self::getAuxiliaryValue() >= 1) {
-      self::setMaxSteps(1);
+      self::setMaxSteps(2);
     }
   }
 

--- a/modules/Innovation/Cards/Base/Card56_4E.php
+++ b/modules/Innovation/Cards/Base/Card56_4E.php
@@ -24,7 +24,7 @@ class Card56_4E extends AbstractCard
   {
     if (self::isFirstNonDemand()) {
       if (self::isFirstInteraction()) {
-        return ['choose_value' => true];
+        return self::youMust()->chooseValue()->build();
       } else {
         return self::youMay()->meld()->all()->value(self::getAuxiliaryValue())->fromYourScore()->build();
       }

--- a/modules/Innovation/Cards/Base/Card62_4E.php
+++ b/modules/Innovation/Cards/Base/Card62_4E.php
@@ -26,7 +26,7 @@ class Card62_4E extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return ['choose_from' => Locations::SCORE];
+      return self::youMust()->chooseCardFrom(Locations::SCORE)->build();
     } else {
       return self::youMust()->return()->all()->value(self::getAuxiliaryValue())->build();
     }

--- a/modules/Innovation/Cards/Base/Card72.php
+++ b/modules/Innovation/Cards/Base/Card72.php
@@ -29,9 +29,9 @@ class Card72 extends AbstractCard
   {
     if (self::isDemand()) {
       if (self::isFirstInteraction()) {
-        return self::youMust()->exactly(2)->lowest()->fromMyHand()->toYours()->ofMyChoice()->build();
+        return self::youMust()->lowest()->fromMyHand()->toYours()->ofMyChoice()->build();
       } else {
-        return self::youMust()->highest()->fromYourHand()->toMine()->build();
+        return self::youMust()->exactly(2)->highest()->fromYourHand()->toMine()->build();
       }
     } else {
       return self::youMust()->choose([7, 8])->build();

--- a/modules/Innovation/Cards/Base/Card91.php
+++ b/modules/Innovation/Cards/Base/Card91.php
@@ -46,7 +46,7 @@ class Card91 extends AbstractCard
   protected function getPromptForListChoice(): array
   {
     return self::buildPromptFromList([
-      1 => [clienttranslate('Junk ${age} deck'), 'age' => self::renderValueWithType(1, CardTypes::BASE)],
+      1 => [clienttranslate('Junk ${age} deck'), 'age' => self::renderValueWithType(10, CardTypes::BASE)],
     ]);
   }
 

--- a/modules/Innovation/Cards/Echoes/Card330.php
+++ b/modules/Innovation/Cards/Echoes/Card330.php
@@ -47,10 +47,7 @@ class Card330 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return [
-      'choose_player' => true,
-      'players'       => self::getAuxiliaryArray(),
-    ];
+    return self::youMust()->choosePlayer(self::getAuxiliaryArray())->build();
   }
 
   public function handlePlayerChoice(int $opponentId)

--- a/modules/Innovation/Cards/Echoes/Card331.php
+++ b/modules/Innovation/Cards/Echoes/Card331.php
@@ -42,25 +42,21 @@ class Card331 extends AbstractCard
     foreach ($playerCards as $playerCard) {
       $matchFound = false;
       foreach ($launcherCards as $launcherCard) {
-        if ($playerCard['faceup_age'] == $launcherCard['faceup_age']) {
+        if (self::getFaceupValue($playerCard) == self::getFaceupValue($launcherCard)) {
           $matchFound = true;
           break;
         }
       }
       if (!$matchFound) {
-        $colors[] = $playerCard['color'];
+        $colors[] = self::getColor($playerCard);
       }
     }
-    return [
-      'location' => 'board',
-      'owner_to' => self::getLauncherId(),
-      'color'    => $colors,
-    ];
+    return self::youMust()->withColor($colors)->fromYourBoard()->toMyBoard()->build();
   }
 
   public function handleCardChoice(array $card)
   {
-    self::drawAndMeld($card['faceup_age']);
+    self::drawAndMeld(self::getFaceupValue($card));
   }
 
 }

--- a/modules/Innovation/Cards/Echoes/Card332.php
+++ b/modules/Innovation/Cards/Echoes/Card332.php
@@ -30,12 +30,11 @@ class Card332 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    $keyword = self::isFirstInteraction() ? 'foreshadow_keyword' : 'return_keyword';
-    return [
-      'location_from'                   => 'hand',
-      $keyword                          => true,
-      'card_ids_are_in_auxiliary_array' => true,
-    ];
+    if (self::isFirstInteraction()) {
+      return self::youMust()->foreshadow()->onlyCardsInAuxiliaryArray()->fromYourHand()->build();
+    } else {
+      return self::youMust()->return()->onlyCardsInAuxiliaryArray()->fromYourHand()->build();
+    }
   }
 
   public function handleCardChoice(array $card)

--- a/modules/Innovation/Cards/Echoes/Card333.php
+++ b/modules/Innovation/Cards/Echoes/Card333.php
@@ -4,6 +4,7 @@ namespace Innovation\Cards\Echoes;
 
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\Colors;
+use Innovation\Enums\Locations;
 
 class Card333 extends AbstractCard
 {
@@ -27,7 +28,7 @@ class Card333 extends AbstractCard
       } else {
         self::setMaxSteps(1);
       }
-    } else if (self::countCards('forecast') === 0) {
+    } else if (self::countCards(Locations::FORECAST) === 0) {
       self::drawAndForeshadow(3);
     }
   }
@@ -35,27 +36,14 @@ class Card333 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstOrThirdEdition()) {
-      return [
-        'location_from'    => 'hand',
-        'tuck_keyword'     => true,
-        'color'            => [Colors::RED],
-        'reveal_if_unable' => true,
-      ];
+      return self::youMust()->tuck()->withColor(Colors::RED)->fromYourHand()->revealingIfUnable()->build();
     } else {
       if (self::isEcho()) {
-        return [
-          'location_from' => 'hand',
-          'tuck_keyword'  => true,
-          'age'           => 1,
-        ];
+        return self::youMust()->tuck()->value(1)->fromYourHand()->build();
       } else if (self::isFirstInteraction()) {
-        return ['choices' => [1, 2]];
+        return self::youMust()->choose([1, 2])->build();
       } else {
-        return [
-          'location_from' => 'forecast',
-          'tuck_keyword'  => true,
-          'age'           => 2,
-        ];
+        return self::youMust()->tuck()->value(2)->fromYourForecast()->build();
       }
     }
   }

--- a/modules/Innovation/Cards/Echoes/Card334.php
+++ b/modules/Innovation/Cards/Echoes/Card334.php
@@ -40,20 +40,9 @@ class Card334 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstOrThirdEdition()) {
-      return [
-        'location'         => 'hand',
-        'owner_to'         => self::getLauncherId(),
-        'with_icon'        => Icons::AUTHORITY,
-        'reveal_if_unable' => true,
-      ];
+      return self::youMust()->withIcon(Icons::AUTHORITY)->fromYourHand()->toMine()->revealingIfUnable()->build();
     } else {
-      return [
-        'location'                        => 'hand',
-        'owner_to'                        => self::getLauncherId(),
-        'with_icons'                      => [Icons::AUTHORITY, Icons::CONCEPT],
-        'enable_autoselection'            => false,
-        'reveal_if_unable'                => true,
-      ];
+      return self::youMust()->withIcons([Icons::AUTHORITY, Icons::CONCEPT])->fromYourHand()->toMine()->revealingIfUnable()->withoutAutoselection()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card335.php
+++ b/modules/Innovation/Cards/Echoes/Card335.php
@@ -27,15 +27,11 @@ class Card335 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    $options = [
-      'location_from' => 'board',
-      'score_keyword' => true,
-      'bottom_from'   => true,
-    ];
     if (self::isFourthEdition()) {
-      $options['color'] = [Colors::BLUE];
+      return self::youMust()->score()->withColor(Colors::BLUE)->fromBottom()->fromYourBoard()->build();
+    } else {
+      return self::youMust()->score()->fromBottom()->fromYourBoard()->build();
     }
-    return $options;
   }
 
 }

--- a/modules/Innovation/Cards/Echoes/Card336.php
+++ b/modules/Innovation/Cards/Echoes/Card336.php
@@ -24,21 +24,11 @@ class Card336 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return ['choose_color' => true];
+      return self::youMust()->chooseColor()->build();
     } else if (self::isSecondInteraction()) {
-      return [
-        'n'              => 'all',
-        'location_from'  => 'revealed',
-        'return_keyword' => true,
-      ];
+      return self::youMust()->return()->all()->fromYourRevealed()->build();
     } else {
-      return [
-        'n'              => 'all',
-        'owner_from'     => 'any player',
-        'location_from'  => 'pile',
-        'return_keyword' => true,
-        'color'          => [self::getAuxiliaryValue()],
-      ];
+      return self::youMust()->return()->entirePile()->withColor(self::getAuxiliaryValue())->fromAnyPlayer()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card337.php
+++ b/modules/Innovation/Cards/Echoes/Card337.php
@@ -33,21 +33,13 @@ class Card337 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return [
-        'can_pass'       => true,
-        'n_min'          => 1,
-        'n_max'          => self::isFirstOrThirdEdition() ? 3 : 2,
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-      ];
+      $maxCards = self::isFirstOrThirdEdition() ? 3 : 2;
+      return self::youMay()->return()->minCards(1)->maxCards($maxCards)->fromYourHand()->build();
     } else if (self::isSecondInteraction()) {
-      return ['choices' => [1, 2]];
+      return self::youMust()->choose([1, 2])->build();
     } else {
-      return [
-        'location_from'  => 'board',
-        'return_keyword' => true,
-        'age'            => self::getMaxValue(self::getTopCards()),
-      ];
+      $value = self::getMaxValue(self::getTopCards());
+      return self::youMust()->return()->value($value)->fromYourBoard()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card338.php
+++ b/modules/Innovation/Cards/Echoes/Card338.php
@@ -14,24 +14,12 @@ class Card338 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'can_pass'      => true,
-        'location_from' => 'hand',
-        'meld_keyword'  => true,
-      ];
+      return self::youMay()->meld()->fromYourHand()->build();
     } else if (self::isFirstInteraction()) {
-      return [
-        'can_pass'       => true,
-        'n_min'          => 1,
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-      ];
+      return self::youMay()->return()->minCards(1)->fromYourHand()->build();
     } else {
-      return [
-        'n'             => self::getAuxiliaryValue() * 2,
-        'location_from' => 'hand',
-        'score_keyword' => true,
-      ];
+      $numCards = self::getAuxiliaryValue() * 2;
+      return self::youMust()->score()->exactly($numCards)->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card339.php
+++ b/modules/Innovation/Cards/Echoes/Card339.php
@@ -33,16 +33,10 @@ class Card339 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return [
-        'can_pass' => true,
-        'choices'  => [1],
-      ];
+      return self::youMay()->choose([1])->build();
     } else {
-      return [
-        'location_from'       => Locations::JUNK,
-        'achieve_if_eligible' => true,
-        'age'                 => self::getMaxValueInLocation(Locations::JUNK),
-      ];
+      $value = self::getMaxValueInLocation(Locations::JUNK);
+      return self::youMust()->achieveIfEligible()->value($value)->fromJunk()->build();
     }
   }
 
@@ -68,7 +62,7 @@ class Card339 extends AbstractCard
     if (self::isEcho()) {
       self::drawAndForeshadow(1);
     } else if (self::isFirstOrThirdEdition()) {
-      $this->game->executeDraw(0, /*age=*/1, Locations::ACHIEVEMENTS, /*bottom_to=*/false, /*type=*/0, /*bottom_from=*/true);
+      $this->game->executeDraw(0, /*age=*/ 1, Locations::ACHIEVEMENTS, /*bottom_to=*/ false, /*type=*/ 0, /*bottom_from=*/ true);
     } else {
       self::junkBaseDeck(1);
       self::setMaxSteps(2);

--- a/modules/Innovation/Cards/Echoes/Card341_3E.php
+++ b/modules/Innovation/Cards/Echoes/Card341_3E.php
@@ -22,22 +22,11 @@ class Card341_3E extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return ['choose_color' => true];
+      return self::youMust()->chooseColor()->build();
     } else if (self::isSecondInteraction()) {
-      return [
-        'can_pass'      => true,
-        'n_min'         => 1,
-        'n_max'         => 'all',
-        'location_from' => Locations::HAND,
-        'tuck_keyword'  => true,
-        'color'         => [self::getAuxiliaryValue()],
-      ];
+      return self::youMay()->tuck()->anyNumber()->withColor(self::getAuxiliaryValue())->fromYourHand()->build();
     } else {
-      return [
-        'can_pass'            => true,
-        'location_from'       => Locations::HAND,
-        'achieve_if_eligible' => true,
-      ];
+      return self::youMay()->achieveIfEligible()->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card341_4E.php
+++ b/modules/Innovation/Cards/Echoes/Card341_4E.php
@@ -23,22 +23,11 @@ class Card341_4E extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return ['choose_color' => true];
+      return self::youMust()->chooseColor()->build();
     } else if (self::isSecondInteraction()) {
-      return [
-        'can_pass'      => true,
-        'n_min'         => 1,
-        'n_max'         => 'all',
-        'location_from' => Locations::HAND,
-        'tuck_keyword'  => true,
-        'color'         => [self::getAuxiliaryValue()],
-      ];
+      return self::youMay()->tuck()->anyNumber()->withColor(self::getAuxiliaryValue())->fromYourHand()->build();
     } else {
-      return [
-        'can_pass'            => true,
-        'location_from'       => Locations::HAND,
-        'achieve_if_eligible' => true,
-      ];
+      return self::youMay()->achieveIfEligible()->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card342.php
+++ b/modules/Innovation/Cards/Echoes/Card342.php
@@ -33,18 +33,9 @@ class Card342 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'can_pass'      => true,
-        'location_from' => 'hand',
-        'score_keyword' => true,
-      ];
+      return self::youMay()->score()->fromYourHand()->build();
     } else {
-      return [
-        'n'              => 'all',
-        'owner_from'     => 'any player',
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-      ];
+      return self::youMust()->return()->all()->fromAnyHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card343.php
+++ b/modules/Innovation/Cards/Echoes/Card343.php
@@ -39,23 +39,12 @@ class Card343 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'can_pass'        => true,
-        'splay_direction' => Directions::LEFT,
-      ];
+      return self::youMay()->splayLeft()->build();
     } else if (self::isFirstOrThirdEdition()) {
-      return [
-        'location_from'    => 'hand',
-        'return_keyword'   => true,
-        'with_bonus'       => true,
-        'reveal_if_unable' => true,
-      ];
+      return self::youMust()->return()->withBonus()->fromYourHand()->revealingIfUnable()->build();
     } else {
-      return [
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-        'type'           => CardTypes::getAllTypesOtherThan(CardTypes::BASE),
-      ];
+      $types = CardTypes::getAllTypesOtherThan(CardTypes::BASE);
+      return self::youMust()->return()->withTypes($types)->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card344.php
+++ b/modules/Innovation/Cards/Echoes/Card344.php
@@ -23,19 +23,15 @@ class Card344 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    $values = self::getUniqueValuesInLocation('score');
+    $values = self::getUniqueValuesInLocation(Locations::SCORE);
     $cardIds = [];
     foreach (self::getCards(Locations::AVAILABLE_ACHIEVEMENTS) as $card) {
-      if (self::isValuedCard($card) && in_array(intval($card['age']), $values)) {
+      if (self::isValuedCard($card) && in_array(intval(self::getValue($card)), $values)) {
         $cardIds[] = self::getId($card);
       }
     }
     self::setAuxiliaryArray($cardIds);
-    return [
-      'location_from'                   => Locations::AVAILABLE_ACHIEVEMENTS,
-      'junk_keyword'                    => true,
-      'card_ids_are_in_auxiliary_array' => true,
-    ];
+    return self::youMust()->junk()->onlyCardsInAuxiliaryArray()->fromAvailableAchievements()->build();
   }
 
 }

--- a/modules/Innovation/Cards/Echoes/Card345.php
+++ b/modules/Innovation/Cards/Echoes/Card345.php
@@ -27,13 +27,7 @@ class Card345 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return [
-        'can_pass'       => true,
-        'n_min'          => 1,
-        'n_max'          => 'all',
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-      ];
+      return self::youMay()->return()->anyNumber()->fromYourHand()->build();
     } else {
       $valuesToDraw = self::getAuxiliaryArray();
       $values = [];
@@ -42,10 +36,7 @@ class Card345 extends AbstractCard
           $values[] = $i;
         }
       }
-      return [
-        'choose_value' => true,
-        'age'          => $values,
-      ];
+      return self::youMust()->chooseValue($values)->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card346.php
+++ b/modules/Innovation/Cards/Echoes/Card346.php
@@ -20,7 +20,7 @@ class Card346 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return ['choices' => [1, 2]];
+      return self::youMust()->choose([1, 2])->build();
     } else if (self::isFirstInteraction()) {
       if (self::isFirstOrThirdEdition()) {
         $values = self::getBonuses();
@@ -30,17 +30,9 @@ class Card346 extends AbstractCard
           $values = array_merge($values, self::getBonuses($playerId));
         }
       }
-      return [
-        'choose_value' => true,
-        'age'          => $values,
-      ];
+      return self::youMust()->chooseValue($values)->build();
     } else {
-      return [
-        'n'             => 'all',
-        'location_from' => Locations::AVAILABLE_ACHIEVEMENTS,
-        'junk_keyword'  => true,
-        'age'           => self::getAuxiliaryValue(),
-      ];
+      return self::youMust()->junk()->all()->value(self::getAuxiliaryValue())->fromAvailableAchievements()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card347.php
+++ b/modules/Innovation/Cards/Echoes/Card347.php
@@ -28,26 +28,17 @@ class Card347 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isDemand()) {
-      $options = [
-        'location_from' => 'hand',
-        'owner_to'      => self::getLauncherId(),
-        'location_to'   => 'score',
-      ];
       if (self::isFirstOrThirdEdition()) {
-        $options['with_bonus'] = true;
+        return self::youMust()->withBonus()->fromYourHand()->toMyScore()->build();
       } else {
-        $options['type'] = CardTypes::getAllTypesOtherThan(CardTypes::BASE);
+        $types = CardTypes::getAllTypesOtherThan(CardTypes::BASE);
+        return self::youMust()->withTypes($types)->fromYourHand()->toMyScore()->build();
       }
-      return $options;
     } else if (self::isFirstInteraction()) {
       $players = self::isFirstOrThirdEdition() ? $this->game->getOtherActivePlayers(self::getPlayerId()) : $this->game->getActiveOpponents(self::getPlayerId());
       return self::youMust()->choosePlayer($players)->build();
     } else {
-      return [
-        'location_from' => 'hand',
-        'owner_to'      => self::getAuxiliaryValue(),
-        'location_to'   => 'board',
-      ];
+      return self::youMust()->fromMyHand()->toPlayer(self::getAuxiliaryValue())->toBoard()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card348.php
+++ b/modules/Innovation/Cards/Echoes/Card348.php
@@ -37,17 +37,10 @@ class Card348 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'can_pass' => true,
-        'choices'  => [2, 3],
-      ];
+      return self::youMay()->choose([2, 3])->build();
     } else {
-      return [
-        'location_from' => Locations::BOARD,
-        'owner_to'      => self::getLauncherId(),
-        'location_to'   => Locations::BOARD,
-        'without_icons' => [Icons::AUTHORITY, Icons::INDUSTRY],
-      ];
+      $icons = [Icons::AUTHORITY, Icons::INDUSTRY];
+      return self::youMust()->withoutIcons($icons)->fromYourBoard()->toMine()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card349.php
+++ b/modules/Innovation/Cards/Echoes/Card349.php
@@ -25,8 +25,8 @@ class Card349 extends AbstractCard
     } else if (self::isFirstNonDemand()) {
       $minValue = null;
       foreach (self::getTopCards() as $card) {
-        if (self::getColor($card) != Colors::GREEN && ($minValue === null || $minValue > $card['faceup_age'])) {
-          $minValue = $card['faceup_age'];
+        if (self::getColor($card) != Colors::GREEN && ($minValue === null || $minValue > self::getFaceupValue($card))) {
+          $minValue = self::getFaceupValue($card);
         }
       }
       if ($minValue === null) {
@@ -41,19 +41,14 @@ class Card349 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      $options = [
-        'location_from' => 'hand',
-        'score_keyword' => true,
-      ];
       if (self::isFirstOrThirdEdition()) {
-        $options['with_bonus'] = true;
-        $options['reveal_if_unable'] = true;
+        return self::youMust()->score()->withBonus()->fromYourHand()->revealingIfUnable()->build();
       } else {
-        $options['type'] = CardTypes::getAllTypesOtherThan(CardTypes::BASE);
+        $types = CardTypes::getAllTypesOtherThan(CardTypes::BASE);
+        return self::youMust()->score()->withTypes($types)->fromYourHand()->build();
       }
-      return $options;
     } else {
-      return ['choices' => [2, 3]];
+      return self::youMust()->choose([2, 3])->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card350.php
+++ b/modules/Innovation/Cards/Echoes/Card350.php
@@ -5,6 +5,7 @@ namespace Innovation\Cards\Echoes;
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\CardIds;
 use Innovation\Enums\Colors;
+use Innovation\Enums\Locations;
 
 class Card350 extends AbstractCard
 {
@@ -37,21 +38,11 @@ class Card350 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'location_from' => 'board',
-        'bottom_from'   => true,
-        'location_to'   => 'hand',
-      ];
+      return self::youMust()->fromYourBoard()->fromBottom()->toYourHand()->build();
     } else if (self::isFirstInteraction() || self::isThirdInteraction()) {
-      return [
-        'can_pass'    => true,
-        'choose_from' => 'hand',
-      ];
+      return self::youMay()->chooseCardFrom(Locations::HAND)->build();
     } else {
-      return [
-        'can_pass' => true,
-        'choices'  => [1, 2],
-      ];
+      return self::youMay()->choose([1, 2])->build();
     }
   }
 
@@ -81,7 +72,7 @@ class Card350 extends AbstractCard
     } else {
       self::score($card);
     }
-    if (self::isSecondInteraction() && self::countCards("hand") > 0) {
+    if (self::isSecondInteraction() && self::countCards(Locations::HAND) > 0) {
       self::setMaxSteps(self::getMaxSteps() + 1);
     }
   }

--- a/modules/Innovation/Cards/Echoes/Card351.php
+++ b/modules/Innovation/Cards/Echoes/Card351.php
@@ -5,6 +5,7 @@ namespace Innovation\Cards\Echoes;
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\CardTypes;
 use Innovation\Enums\Directions;
+use Innovation\Enums\Locations;
 
 class Card351 extends AbstractCard
 {
@@ -22,7 +23,7 @@ class Card351 extends AbstractCard
   public function initialExecution()
   {
     if (self::isEcho()) {
-      $values = self::getUniqueValuesInLocation('hand');
+      $values = self::getUniqueValuesInLocation(Locations::HAND);
       if (count($values) > 0) {
         self::setMaxSteps(2);
         self::setAuxiliaryArray($values);
@@ -36,34 +37,17 @@ class Card351 extends AbstractCard
   {
     if (self::isEcho()) {
       if (self::isFirstInteraction()) {
-        return [
-          'choose_value' => true,
-          'age'          => self::getAuxiliaryArray(),
-        ];
+        return self::youMust()->chooseValue(self::getAuxiliaryArray())->build();
       } else {
-        return [
-          'n'             => 'all',
-          'location_from' => 'hand',
-          'tuck_keyword'  => true,
-          'age'           => self::getAuxiliaryValue(),
-        ];
+        return self::youMust()->tuck()->all()->value(self::getAuxiliaryValue())->fromYourHand()->build();
       }
     } else if (self::isFirstNonDemand()) {
-      return [
-        'can_pass'        => true,
-        'splay_direction' => Directions::LEFT,
-      ];
+      return self::youMay()->splayLeft()->build();
     } else if (self::isFirstInteraction()) {
-      return [
-        'can_pass' => true,
-        'choices'  => [1],
-      ];
+      return self::youMay()->choose([1])->build();
     } else {
-      return [
-        'location_from'       => 'junk',
-        'age'                 => self::getMaxValueInLocation('junk'),
-        'achieve_if_eligible' => true
-      ];
+      $value = self::getMaxValueInLocation(Locations::JUNK);
+      return self::youMust()->achieveIfEligible()->value($value)->fromJunk()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card352.php
+++ b/modules/Innovation/Cards/Echoes/Card352.php
@@ -22,29 +22,14 @@ class Card352 extends AbstractCard
   {
     if (self::isFirstOrThirdEdition()) {
       if (self::isFirstInteraction()) {
-        return [
-          'location_from'    => 'hand',
-          'tuck_keyword'     => true,
-          'with_bonus'       => true,
-          'reveal_if_unable' => true,
-        ];
+        return self::youMust()->tuck()->withBonus()->fromYourHand()->revealingIfUnable()->build();
       } else {
-        return [
-          'can_pass'       => true,
-          'location_from'  => 'hand',
-          'return_keyword' => true,
-        ];
+        return self::youMay()->return()->fromYourHand()->build();
       }
     } else if (self::isFirstNonDemand()) {
-      return [
-        'choose_value' => true,
-        'age'          => self::getBonuses(),
-      ];
+      return self::youMust()->chooseValue(self::getBonuses())->build();
     } else {
-      return [
-        'location_from' => 'hand',
-        'tuck_keyword'  => true,
-      ];
+      return self::youMust()->tuck()->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card352.php
+++ b/modules/Innovation/Cards/Echoes/Card352.php
@@ -61,7 +61,7 @@ class Card352 extends AbstractCard
         self::setMaxSteps(1);
       }
     } else if (self::isSecondNonDemand() && self::wasForeseen()) {
-      while ($topCard = $this->game->getDeckTopCard($card['age'], CardTypes::BASE)) {
+      while ($topCard = $this->game->getDeckTopCard(self::getValue($card), CardTypes::BASE)) {
         self::tuck($topCard);
       }
     }

--- a/modules/Innovation/Cards/Echoes/Card353.php
+++ b/modules/Innovation/Cards/Echoes/Card353.php
@@ -26,21 +26,11 @@ class Card353 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    $color = self::getCard(self::getAuxiliaryValue())['color'];
+    $color = self::getColor(self::getCard(self::getAuxiliaryValue()));
     if (self::isFirstInteraction()) {
-      return [
-        'can_pass'      => self::isFourthEdition(),
-        'location_from' => 'hand',
-        'tuck_keyword'  => true,
-        'color'         => [$color],
-      ];
+      return self::youMay()->tuck()->fromYourHand()->withColor([$color])->build();
     } else {
-      return [
-        'n'             => 'all',
-        'owner_from'    => 'any other player',
-        'location_from' => 'pile',
-        'color'         => [$color],
-      ];
+      return self::youMust()->return()->entirePile()->withColor([$color])->fromAnyPlayer()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card354.php
+++ b/modules/Innovation/Cards/Echoes/Card354.php
@@ -28,12 +28,11 @@ class Card354 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return [
-      'location_from'    => 'hand',
-      'meld_keyword'     => true,
-      'with_bonus'       => self::isFirstOrThirdEdition(),
-      'reveal_if_unable' => self::isFirstOrThirdEdition(),
-    ];
+    if (self::isFirstOrThirdEdition()) {
+      return self::youMay()->meld()->withBonus()->fromYourHand()->revealingIfUnable()->build();
+    } else {
+      return self::youMust()->meld()->fromYourHand()->build();
+    }
   }
 
   public function handleCardChoice(array $card)

--- a/modules/Innovation/Cards/Echoes/Card355.php
+++ b/modules/Innovation/Cards/Echoes/Card355.php
@@ -37,24 +37,11 @@ class Card355 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstNonDemand()) {
-      return [
-        'can_pass'      => true,
-        'location_from' => 'forecast',
-        'location_to'   => 'revealed,deck',
-        'with_bonus'    => true,
-      ];
+      return self::youMay()->revealAndReturn()->withBonus()->fromYourForecast()->build();
     } else if (self::isFirstInteraction()) {
-      return [
-        'choose_player' => true,
-        'players'       => $this->game->getOtherActivePlayers(self::getPlayerId()),
-      ];
+      return self::youMust()->choosePlayer(self::getOtherPlayers())->build();
     } else {
-      return [
-        'n'                  => 'all',
-        'owner_from'         => self::getAuxiliaryValue(),
-        'location_from'      => 'forecast',
-        'foreshadow_keyword' => true,
-      ];
+      return self::youMust()->foreshadow()->all()->fromForecast(self::getAuxiliaryValue())->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card356.php
+++ b/modules/Innovation/Cards/Echoes/Card356.php
@@ -4,7 +4,7 @@ namespace Innovation\Cards\Echoes;
 
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\Colors;
-use Innovation\Enums\Directions;
+use Innovation\Enums\Locations;
 use Innovation\Utils\Arrays;
 
 class Card356 extends AbstractCard
@@ -41,32 +41,18 @@ class Card356 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-      ];
+      return self::youMust()->return()->fromYourHand()->build();
     } else if (self::isFirstNonDemand()) {
       if (self::isFirstInteraction()) {
-        return [
-          'can_pass'     => true,
-          'choose_value' => true,
-          'age'          => Arrays::decode(self::getAuxiliaryValue()),
-        ];
+        $values = Arrays::decode(self::getAuxiliaryValue());
+        return self::youMay()->chooseValue($values)->build();
       } else {
-        return [
-          'can_pass'       => true,
-          'n'              => 3,
-          'location_from'  => 'hand',
-          'return_keyword' => true,
-          'age'            => self::getAuxiliaryValue(),
-        ];
+        $value = self::getAuxiliaryValue();
+        return self::youMay()->return()->exactly(3)->value($value)->fromYourHand()->build();
       }
     } else {
-      return [
-        'can_pass'        => true,
-        'splay_direction' => Directions::LEFT,
-        'color'           => [Colors::YELLOW, Colors::BLUE],
-      ];
+      $colors = [Colors::YELLOW, Colors::BLUE];
+      return self::youMay()->splayLeft()->withColor($colors)->build();
     }
   }
 
@@ -84,7 +70,7 @@ class Card356 extends AbstractCard
 
   private function getValuesWithThreeOrMoreInHand(): array
   {
-    $cardsByValue = self::getCardsKeyedByValue('hand');
+    $cardsByValue = self::getCardsKeyedByValue(Locations::HAND);
     $values = [];
     for ($i = 1; $i <= 11; $i++) {
       if (count($cardsByValue[$i]) >= 3) {

--- a/modules/Innovation/Cards/Echoes/Card357.php
+++ b/modules/Innovation/Cards/Echoes/Card357.php
@@ -3,6 +3,7 @@
 namespace Innovation\Cards\Echoes;
 
 use Innovation\Cards\AbstractCard;
+use Innovation\Enums\Locations;
 
 class Card357 extends AbstractCard
 {
@@ -18,7 +19,7 @@ class Card357 extends AbstractCard
     $card = self::drawAndReveal($maxBonus);
     self::transferToForecast($card, [$this, 'transferToHand'], self::getLauncherId());
     if (self::isRed($card)) {
-      foreach (self::getCards('hand') as $card) {
+      foreach (self::getCards(Locations::HAND) as $card) {
         self::transferToScorePile($card, self::getLauncherId());
       }
     }

--- a/modules/Innovation/Cards/Echoes/Card358.php
+++ b/modules/Innovation/Cards/Echoes/Card358.php
@@ -29,12 +29,7 @@ class Card358 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return [
-      'location_from' => 'board',
-      'owner_to'      => self::getLauncherId(),
-      'location_to'   => 'score',
-      'with_icon'     => Icons::AUTHORITY,
-    ];
+    return self::youMust()->withIcon(Icons::AUTHORITY)->fromYourBoard()->toMyScore()->build();
   }
 
   public function handleCardChoice(array $card)

--- a/modules/Innovation/Cards/Echoes/Card359.php
+++ b/modules/Innovation/Cards/Echoes/Card359.php
@@ -121,9 +121,9 @@ class Card359 extends AbstractCard
     if (self::isFirstOrThirdEdition()) {
       self::setAuxiliaryValue($topGreenCard['id']); // Track card ID which will be returned or achieved
       self::setMaxSteps(2);
-    } else if ($card['age'] == 3) {
+    } else if (self::getValue($card) == 3) {
       self::achieveIfEligible($topGreenCard);
-    } else if ($card['age'] == 4) {
+    } else if (self::getValue($card) == 4) {
       self::return($topGreenCard);
     }
   }

--- a/modules/Innovation/Cards/Echoes/Card359.php
+++ b/modules/Innovation/Cards/Echoes/Card359.php
@@ -35,30 +35,22 @@ class Card359 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return ['choices' => [3, 4]];
+      return self::youMust()->choose([3, 4])->build();
     } else if (self::isFirstInteraction()) {
       if (count(self::getActionScopedAuxiliaryArray(self::getPlayerId())) === 2) {
         // If two cards were drawn due to the Endorse action, the launcher is allowed to choose to meld
         // the same card twice. Unfortunately, this means the card may no longer be in a visible
         // location so we need to use a special prompt.
-        return [
-          'can_pass' => true,
-          'choices'  => [0, 1],
-        ];
+        return self::youMay()->choose([0, 1])->build();
       } else {
         self::setAuxiliaryArray(self::getActionScopedAuxiliaryArray(self::getPlayerId()));
-        return [
-          'can_pass'                        => true,
-          'location_from'                   => 'hand',
-          'meld_keyword'                    => true,
-          'card_ids_are_in_auxiliary_array' => true,
-        ];
+        return self::youMay()->meld()->onlyCardsInAuxiliaryArray()->fromYourHand()->build();
       }
     } else {
       if (self::isEligibleForAchieving(self::getCard(self::getAuxiliaryValue()))) {
-        return ['choices' => [1, 2]];
+        return self::youMust()->choose([1, 2])->build();
       } else {
-        return ['choices' => [1]];
+        return self::youMust()->choose([1])->build();
       }
     }
 
@@ -119,7 +111,7 @@ class Card359 extends AbstractCard
       return;
     }
     if (self::isFirstOrThirdEdition()) {
-      self::setAuxiliaryValue($topGreenCard['id']); // Track card ID which will be returned or achieved
+      self::setAuxiliaryValue(self::getId($topGreenCard)); // Track card ID which will be returned or achieved
       self::setMaxSteps(2);
     } else if (self::getValue($card) == 3) {
       self::achieveIfEligible($topGreenCard);

--- a/modules/Innovation/Cards/Echoes/Card360.php
+++ b/modules/Innovation/Cards/Echoes/Card360.php
@@ -24,7 +24,7 @@ class Card360 extends AbstractCard
       $cardIds = [];
       $handCounts = self::countCardsKeyedByValue('hand', self::getLauncherId());
       foreach (self::getCards('score') as $card) {
-        if ($handCounts[$card['age']] > 0) {
+        if ($handCounts[self::getValue($card)] > 0) {
           $cardIds[] = self::getId($card);
         }
       }

--- a/modules/Innovation/Cards/Echoes/Card360.php
+++ b/modules/Innovation/Cards/Echoes/Card360.php
@@ -5,6 +5,7 @@ namespace Innovation\Cards\Echoes;
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\Colors;
 use Innovation\Enums\Directions;
+use Innovation\Enums\Locations;
 
 class Card360 extends AbstractCard
 {
@@ -22,7 +23,7 @@ class Card360 extends AbstractCard
   {
     if (self::isDemand()) {
       $cardIds = [];
-      $handCounts = self::countCardsKeyedByValue('hand', self::getLauncherId());
+      $handCounts = self::countCardsKeyedByValue(Locations::HAND, self::getLauncherId());
       foreach (self::getCards('score') as $card) {
         if ($handCounts[self::getValue($card)] > 0) {
           $cardIds[] = self::getId($card);
@@ -39,18 +40,9 @@ class Card360 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isDemand()) {
-      return [
-        'n'                               => 2,
-        'location_from'                   => 'score',
-        'return_keyword'                  => true,
-        'card_ids_are_in_auxiliary_array' => true,
-      ];
+      return self::youMust()->return()->exactly(2)->onlyCardsInAuxiliaryArray()->fromYourScore()->build();
     } else {
-      return [
-        'can_pass'        => true,
-        'splay_direction' => Directions::LEFT,
-        'color'           => [Colors::RED, Colors::GREEN],
-      ];
+      return self::youMay()->splayLeft()->withColor([Colors::RED, Colors::GREEN])->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card362.php
+++ b/modules/Innovation/Cards/Echoes/Card362.php
@@ -27,24 +27,11 @@ class Card362 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::getEffectNumber() === 1 && self::isFirstInteraction()) {
-      return [
-        'can_pass'       => true,
-        'n_min'          => 1,
-        'n_max'          => 'all',
-        'location_from'  => 'hand',
-        'return_keyword' => true,
-      ];
+      return self::youMay()->return()->anyNumber()->fromYourHand()->build();
     } else if (self::isFirstOrThirdEdition() || self::getEffectNumber() === 2) {
-      return [
-        'location_from' => 'hand',
-        'meld_keyword'  => true,
-      ];
+      return self::youMust()->meld()->fromYourHand()->build();
     } else {
-      return [
-        'n'                  => 'all',
-        'location_from'      => 'hand',
-        'foreshadow_keyword' => true,
-      ];
+      return self::youMust()->foreshadow()->all()->fromYourHand()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card363.php
+++ b/modules/Innovation/Cards/Echoes/Card363.php
@@ -49,17 +49,9 @@ class Card363 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'n'              => 'all',
-        'location_from'  => 'forecast',
-        'return_keyword' => true,
-      ];
+      return self::youMust()->return()->all()->fromYourForecast()->build();
     } else {
-      return [
-        'can_pass'        => true,
-        'splay_direction' => Directions::LEFT,
-        'color'           => [Colors::PURPLE],
-      ];
+      return self::youMay()->splayLeft()->withColor([Colors::PURPLE])->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card364.php
+++ b/modules/Innovation/Cards/Echoes/Card364.php
@@ -5,6 +5,7 @@ namespace Innovation\Cards\Echoes;
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\Colors;
 use Innovation\Enums\Directions;
+use Innovation\Enums\Locations;
 
 class Card364 extends AbstractCard
 {
@@ -34,11 +35,7 @@ class Card364 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'location_from' => 'hand',
-        'score_keyword' => true,
-        'color'         => self::getAuxiliaryArray(),
-      ];
+      return self::youMust()->score()->withColor(self::getAuxiliaryArray())->fromYourHand()->build();
     } else {
       $choices = [];
       $purpleSplayDirection = self::getSplayDirection(Colors::PURPLE);
@@ -52,10 +49,7 @@ class Card364 extends AbstractCard
           $choices[] = 5 + $color;
         }
       }
-      return [
-        'can_pass' => true,
-        'choices'  => $choices,
-      ];
+      return self::youMay()->choose($choices)->build();
     }
   }
 
@@ -93,7 +87,7 @@ class Card364 extends AbstractCard
 
   private function mayBeSplayedInDirection(int $color, int $splayDirection): bool
   {
-    return $splayDirection > 0 && self::countCardsKeyedByColor('board')[$color] >= 2 && self::getSplayDirection($color) != $splayDirection;
+    return $splayDirection > 0 && self::countCardsKeyedByColor(Locations::BOARD)[$color] >= 2 && self::getSplayDirection($color) != $splayDirection;
   }
 
 }

--- a/modules/Innovation/Cards/Echoes/Card365.php
+++ b/modules/Innovation/Cards/Echoes/Card365.php
@@ -30,11 +30,7 @@ class Card365 extends AbstractCard
 
   public function getInteractionOptions(): array
   {
-    return [
-      'can_pass'        => true,
-      'splay_direction' => Directions::RIGHT,
-      'color'           => [Colors::YELLOW],
-    ];
+    return self::youMay()->splayRight()->withColor([Colors::YELLOW])->build();
   }
 
 }

--- a/modules/Innovation/Cards/Echoes/Card366.php
+++ b/modules/Innovation/Cards/Echoes/Card366.php
@@ -36,29 +36,17 @@ class Card366 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isFirstInteraction()) {
-      return [
-        'can_pass'      => true,
-        'location_from' => 'forecast',
-        'location_to'   => 'deck',
-        'bottom_to'     => false, // put on top
-      ];
+      return self::youMay()->topDeck()->fromYourForecast()->build();
     } else if (self::isFirstOrThirdEdition()) {
-      return [
-        'location_from'       => 'forecast',
-        'achieve_if_eligible' => true,
-      ];
+      return self::youMust()->achieveIfEligible()->fromYourForecast()->build();
     } else {
       self::setAuxiliaryArray(self::getAvailableStandardAchievementIds());
-      $forecastCards = self::getCards('forecast');
+      $forecastCards = self::getCards(Locations::FORECAST);
       foreach ($forecastCards as $card) {
-        $this->game->transferCardFromTo($card, 0, 'achievements');
+        $this->game->transferCardFromTo($card, 0, Locations::ACHIEVEMENTS);
       }
-      return [
-        'n'                               => count($forecastCards),
-        'location_from'                   => Locations::AVAILABLE_ACHIEVEMENTS,
-        'location_to'                     => 'forecast',
-        'card_ids_are_in_auxiliary_array' => true,
-      ];
+      $numCards = count($forecastCards);
+      return self::youMay()->exactly($numCards)->onlyCardsInAuxiliaryArray()->fromAvailableAchievements()->toForecast()->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card367.php
+++ b/modules/Innovation/Cards/Echoes/Card367.php
@@ -4,6 +4,7 @@ namespace Innovation\Cards\Echoes;
 
 use Innovation\Cards\AbstractCard;
 use Innovation\Enums\Icons;
+use Innovation\Enums\Locations;
 
 class Card367 extends AbstractCard
 {
@@ -43,17 +44,9 @@ class Card367 extends AbstractCard
   public function getInteractionOptions(): array
   {
     if (self::isEcho()) {
-      return [
-        'owner_from'  => 'any player',
-        'choose_from' => 'board',
-      ];
+      return self::youMay()->chooseCardFrom(Locations::BOARD)->fromAnyPlayer()->build();
     } else {
-      return [
-        'n'              => 'all',
-        'location_from'  => 'board',
-        'return_keyword' => true,
-        'with_icon'      => Icons::AUTHORITY,
-      ];
+      return self::youMust()->return()->all()->fromYourBoard()->withIcon(Icons::AUTHORITY)->build();
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card372_3E.php
+++ b/modules/Innovation/Cards/Echoes/Card372_3E.php
@@ -52,7 +52,7 @@ class Card372_3E extends AbstractCard
   public function handleCardChoice(array $card)
   {
     if (self::isFirstInteraction()) {
-      self::setAuxiliaryValue(max(self::getAuxiliaryValue(), $card['age']));
+      self::setAuxiliaryValue(max(self::getAuxiliaryValue(), self::getValue($card)));
     } else if (self::isSecondInteraction()) {
       self::removeFromAuxiliaryArray(self::getId($card));
     }

--- a/modules/Innovation/Cards/Echoes/Card383.php
+++ b/modules/Innovation/Cards/Echoes/Card383.php
@@ -19,7 +19,7 @@ class Card383 extends AbstractCard
     } else {
       $values = [];
       foreach (self::getTopCards() as $card) {
-        $values[] = $card['faceup_age'];
+        $values[] = self::getFaceupValue($card);
       }
       if (count(array_unique($values)) === 5) {
         self::setMaxSteps(1);

--- a/modules/Innovation/Cards/Echoes/Card385_3E.php
+++ b/modules/Innovation/Cards/Echoes/Card385_3E.php
@@ -42,7 +42,7 @@ class Card385_3E extends AbstractCard
   public function handleCardChoice(array $card)
   {
     if (self::isFirstNonDemand()) {
-      self::drawAndForeshadow($card['age']);
+      self::drawAndForeshadow(self::getValue($card));
     }
   }
 

--- a/modules/Innovation/Cards/Echoes/Card387.php
+++ b/modules/Innovation/Cards/Echoes/Card387.php
@@ -70,7 +70,7 @@ class Card387 extends AbstractCard
       if (self::isFirstInteraction()) {
         $cardIds = [];
         foreach (self::getCards('score') as $scoreCard) {
-          if ($scoreCard['age'] != $card['age']) {
+          if ($scoreCard['age'] != self::getValue($card)) {
             $cardIds[] = $scoreCard['id'];
           }
         }

--- a/modules/Innovation/Cards/Echoes/Card389.php
+++ b/modules/Innovation/Cards/Echoes/Card389.php
@@ -36,7 +36,7 @@ class Card389 extends AbstractCard
     foreach ($playerIds as $playerId) {
       $achievementCounts = self::countCardsKeyedByValue('achievements', $playerId);
       foreach (self::getTopCards($playerId) as $card) {
-        if ($achievementCounts[$card['faceup_age']] > 0) {
+        if ($achievementCounts[self::getFaceupValue($card)] > 0) {
           $cardIds[] = self::getId($card);
         }
       }

--- a/modules/Innovation/Cards/Echoes/Card392.php
+++ b/modules/Innovation/Cards/Echoes/Card392.php
@@ -68,7 +68,7 @@ class Card392 extends AbstractCard
   public function handleCardChoice(array $card)
   {
     if (self::isDemand()) {
-      $maxValue = max(self::getAuxiliaryValue(), $card['age']);
+      $maxValue = max(self::getAuxiliaryValue(), self::getValue($card));
       self::setAuxiliaryValue($maxValue);
     }
   }
@@ -92,7 +92,7 @@ class Card392 extends AbstractCard
   {
     $cardIds = [];
     foreach ($cards as $card) {
-      if ($card['age'] % 2 == 1) {
+      if (self::getValue($card) % 2 == 1) {
         $cardIds[] = self::getId($card);
       }
     }

--- a/modules/Innovation/Cards/Echoes/Card394.php
+++ b/modules/Innovation/Cards/Echoes/Card394.php
@@ -58,7 +58,7 @@ class Card394 extends AbstractCard
   public function junkAchievementsOfLowerValue($value)
   {
     foreach (self::getCards(Locations::AVAILABLE_ACHIEVEMENTS) as $card) {
-      if (self::isValuedCard($card) && $card['age'] < $value) {
+      if (self::isValuedCard($card) && self::getValue($card) < $value) {
         self::junk($card);
       }
     }

--- a/modules/Innovation/Cards/Echoes/Card402.php
+++ b/modules/Innovation/Cards/Echoes/Card402.php
@@ -37,9 +37,10 @@ class Card402 extends AbstractCard
     }
   }
 
-  public function handleCardChoice(array $card) {
-    if (self::isFirstNonDemand()&& self::isFirstInteraction()) {
-      $value = $card['age'];
+  public function handleCardChoice(array $card)
+  {
+    if (self::isFirstNonDemand() && self::isFirstInteraction()) {
+      $value = self::getValue($card);
       foreach (self::getPlayerIds() as $playerId) {
         foreach (self::getCardsKeyedByValue('score', $playerId)[$value] as $scoreCard) {
           self::transferToHand($scoreCard);
@@ -48,8 +49,9 @@ class Card402 extends AbstractCard
     }
   }
 
-  public function handleValueChoice($value) {
+  public function handleValueChoice($value)
+  {
     self::drawAndForeshadow($value);
   }
-  
+
 }

--- a/modules/Innovation/Cards/Echoes/Card419.php
+++ b/modules/Innovation/Cards/Echoes/Card419.php
@@ -50,8 +50,8 @@ class Card419 extends AbstractCard
 
   public function handleCardChoice(array $card)
   {
-    $scoredCard = self::drawAndScore($card['faceup_age']);
-    if ($scoredCard['age'] == $card['faceup_age'] && self::wasForeseen()) {
+    $scoredCard = self::drawAndScore(self::getFaceupValue($card));
+    if ($scoredCard['age'] == self::getFaceupValue($card) && self::wasForeseen()) {
       self::setNextStep(1);
     }
   }

--- a/modules/Innovation/Cards/Echoes/Card430_4E.php
+++ b/modules/Innovation/Cards/Echoes/Card430_4E.php
@@ -33,7 +33,7 @@ class Card430_4E extends AbstractCard
       $values = self::getActionScopedAuxiliaryArray();
       $cardIds = [];
       foreach (self::getCards('score') as $card) {
-        if (in_array($card['age'], $values)) {
+        if (in_array(self::getValue($card), $values)) {
           $cardIds[] = self::getId($card);
         }
       }
@@ -54,7 +54,7 @@ class Card430_4E extends AbstractCard
   function handleCardChoice(array $card)
   {
     if (self::isDemand()) {
-      $remainingValues = self::removeFromActionScopedAuxiliaryArray($card['age']);
+      $remainingValues = self::removeFromActionScopedAuxiliaryArray(self::getValue($card));
       if (count($remainingValues) > 0) {
         self::setNextStep(1);
       }

--- a/modules/Innovation/Cards/Echoes/Card470.php
+++ b/modules/Innovation/Cards/Echoes/Card470.php
@@ -43,7 +43,7 @@ class Card470 extends AbstractCard
     if ($choice === 2) {
       self::score($card);
       self::repeatIfForeseen(self::getColor($card));
-    } else if (in_array($card['age'], $this->game->getClaimableValuesIgnoringAvailability(self::getPlayerId()))) {
+    } else if (in_array(self::getValue($card), $this->game->getClaimableValuesIgnoringAvailability(self::getPlayerId()))) {
       self::achieve($card);
       self::repeatIfForeseen(self::getColor($card));
     }

--- a/modules/Innovation/Cards/InteractionBuilder.php
+++ b/modules/Innovation/Cards/InteractionBuilder.php
@@ -144,13 +144,40 @@ class InteractionBuilder
     return $this;
   }
 
+  function withIcons(array $icons): InteractionBuilder
+  {
+    $this->interactionOptions['with_icons'] = $icons;
+    return $this;
+  }
+
   function withoutIcon(string $icon): InteractionBuilder
   {
     $this->interactionOptions['without_icon'] = $icon;
     return $this;
   }
 
+  function withoutIcons(array $icons): InteractionBuilder
+  {
+    $this->interactionOptions['without_icons'] = $icons;
+    return $this;
+  }
+
   // COLOR OF CARDS
+
+  function withBonus(): InteractionBuilder
+  {
+    $this->interactionOptions['with_bonus'] = true;
+    return $this;
+  }
+
+  function withTypes(int|array $types): InteractionBuilder
+  {
+    if (!is_array($types)) {
+      $types = [$types];
+    }
+    $this->interactionOptions['type'] = $types;
+    return $this;
+  }
 
   function withColor(int|array $colors): InteractionBuilder
   {
@@ -213,6 +240,12 @@ class InteractionBuilder
 
   // SOURCE LOCATION
 
+  function fromJunk(): InteractionBuilder
+  {
+    $this->interactionOptions['location_from'] = Locations::JUNK;
+    return $this;
+  }
+
   function fromAvailableAchievements(): InteractionBuilder
   {
     $this->interactionOptions['location_from'] = Locations::AVAILABLE_ACHIEVEMENTS;
@@ -222,6 +255,13 @@ class InteractionBuilder
   function fromYourAchievements(): InteractionBuilder
   {
     $this->interactionOptions['location_from'] = Locations::ACHIEVEMENTS;
+    $this->interactionOptions['owner_from'] = $this->state->getPlayerId();
+    return $this;
+  }
+
+  function fromYourForecast(): InteractionBuilder
+  {
+    $this->interactionOptions['location_from'] = Locations::FORECAST;
     $this->interactionOptions['owner_from'] = $this->state->getPlayerId();
     return $this;
   }
@@ -345,6 +385,13 @@ class InteractionBuilder
     return $this;
   }
 
+  function entirePile(): InteractionBuilder
+  {
+    $this->interactionOptions['n'] = 'all';
+    $this->interactionOptions['location_from'] = Locations::PILE;
+    return $this;
+  }
+
   function fromAnyPlayer(): InteractionBuilder
   {
     $this->interactionOptions['owner_from'] = 'any player';
@@ -354,6 +401,13 @@ class InteractionBuilder
   function fromAnyOtherPlayer(): InteractionBuilder
   {
     $this->interactionOptions['owner_from'] = 'any other player';
+    return $this;
+  }
+
+  function fromAnyHand(): InteractionBuilder
+  {
+    $this->interactionOptions['owner_from'] = 'any player';
+    $this->interactionOptions['location_from'] = Locations::HAND;
     return $this;
   }
 
@@ -435,6 +489,12 @@ class InteractionBuilder
   function toHand(): InteractionBuilder
   {
     $this->interactionOptions['location_to'] = Locations::HAND;
+    return $this;
+  }
+
+  function foreshadow(): InteractionBuilder
+  {
+    $this->interactionOptions['foreshadow_keyword'] = true;
     return $this;
   }
 

--- a/modules/Innovation/Cards/InteractionBuilder.php
+++ b/modules/Innovation/Cards/InteractionBuilder.php
@@ -266,6 +266,14 @@ class InteractionBuilder
     return $this;
   }
 
+  function fromForecast(int $playerId): InteractionBuilder
+  {
+    $this->interactionOptions['location_from'] = Locations::FORECAST;
+    $this->interactionOptions['owner_from'] = $playerId;
+    return $this;
+  }
+
+
   function fromYourRevealed(): InteractionBuilder
   {
     $this->interactionOptions['location_from'] = Locations::REVEALED;
@@ -308,7 +316,7 @@ class InteractionBuilder
     return $this;
   }
 
-  function fromBoard($playerId): InteractionBuilder
+  function fromBoard(int $playerId): InteractionBuilder
   {
     $this->interactionOptions['choose_from'] = Locations::BOARD;
     $this->interactionOptions['owner_from'] = $playerId;

--- a/modules/Innovation/Cards/Unseen/Card482.php
+++ b/modules/Innovation/Cards/Unseen/Card482.php
@@ -22,7 +22,7 @@ class Card482 extends AbstractCard
       $countsByValue = self::countCardsKeyedByValue(Locations::HAND);
       foreach (self::getCards(Locations::AVAILABLE_ACHIEVEMENTS) as $card) {
         if (self::isValuedCard($card)) {
-          if ($countsByValue[$card['age']] > 0) {
+          if ($countsByValue[self::getValue($card)] > 0) {
             $cardIds[] = self::getId($card);
           }
         }

--- a/modules/Innovation/Cards/Unseen/Card505.php
+++ b/modules/Innovation/Cards/Unseen/Card505.php
@@ -33,7 +33,7 @@ class Card505 extends AbstractCard
   public function afterInteraction()
   {
     $card = self::drawAndMeld(self::getAuxiliaryValue());
-    self::setActionScopedAuxiliaryArray([$card['age']]);
+    self::setActionScopedAuxiliaryArray([self::getValue($card)]);
     $stack = self::getStack(self::getColor($card));
     $numCards = count($stack);
     if ($numCards >= 2 && self::hasIcon($stack[$numCards - 2], Icons::CONCEPT)) {

--- a/modules/Innovation/Cards/Unseen/Card518.php
+++ b/modules/Innovation/Cards/Unseen/Card518.php
@@ -21,13 +21,13 @@ class Card518 extends AbstractCard
       $cardIds = [];
       $maxValueInHand = self::getMaxValueInLocation('hand');
       foreach (self::getCards('hand') as $card) {
-        if ($card['age'] < $maxValueInHand) {
+        if (self::getValue($card) < $maxValueInHand) {
           $cardIds[] = self::getId($card);
         }
       }
       $maxValueInScore = self::getMaxValueInLocation('score');
       foreach (self::getCards('score') as $card) {
-        if ($card['age'] < $maxValueInScore) {
+        if (self::getValue($card) < $maxValueInScore) {
           $cardIds[] = self::getId($card);
         }
       }

--- a/modules/Innovation/Cards/Unseen/Card522.php
+++ b/modules/Innovation/Cards/Unseen/Card522.php
@@ -38,7 +38,7 @@ class Card522 extends AbstractCard
       $card = self::draw($valueToDraw);
       // "If you don't" happens whenever you either are unable to transfer a secret or you draw a
       // card of a different value than one higher of the transferred secret.
-      if (self::getNumChosen() === 0 || $card['age'] != $valueToDraw) {
+      if (self::getNumChosen() === 0 || self::getValue($card) != $valueToDraw) {
         self::setMaxSteps(2);
       }
     }

--- a/modules/Innovation/Cards/Unseen/Card535.php
+++ b/modules/Innovation/Cards/Unseen/Card535.php
@@ -38,7 +38,7 @@ class Card535 extends AbstractCard
   public function handleCardChoice(array $card)
   {
     self::incrementAuxiliaryValue();
-    if ($card['age'] == 7) {
+    if (self::getValue($card) == 7) {
       self::setAuxiliaryValue2(self::getAuxiliaryValue2() + 1);
     }
   }

--- a/modules/Innovation/Cards/Unseen/Card579.php
+++ b/modules/Innovation/Cards/Unseen/Card579.php
@@ -34,7 +34,7 @@ class Card579 extends AbstractCard
 
   public function handleCardChoice(array $card)
   {
-    self::addToAuxiliaryArray($card['age']);
+    self::addToAuxiliaryArray(self::getValue($card));
   }
 
   public function afterInteraction()

--- a/modules/Innovation/Cards/Unseen/Card582.php
+++ b/modules/Innovation/Cards/Unseen/Card582.php
@@ -14,13 +14,13 @@ class Card582 extends AbstractCard
   {
     $values = [];
     foreach (self::getTopCards() as $card) {
-      if (!in_array($card['faceup_age'], $values)) {
-        $values[] = $card['faceup_age'];
+      if (!in_array(self::getFaceupValue($card), $values)) {
+        $values[] = self::getFaceupValue($card);
       }
     }
     foreach (self::getCards('score') as $card) {
-      if (!in_array($card['age'], $values)) {
-        $values[] = $card['age'];
+      if (!in_array(self::getValue($card), $values)) {
+        $values[] = self::getValue($card);
       }
     }
     // For each value, in ascending order, if that value is not a value of a top card on your board or a card in your score pile, draw and score a card of that value.

--- a/modules/Innovation/Cards/Unseen/Card583.php
+++ b/modules/Innovation/Cards/Unseen/Card583.php
@@ -67,7 +67,7 @@ class Card583 extends AbstractCard
   public function handleCardChoice(array $card)
   {
     if (self::isSecondInteraction()) {
-      self::setAuxiliaryValue($card['age']);
+      self::setAuxiliaryValue(self::getValue($card));
     } else {
       self::incrementAuxiliaryValue();
     }


### PR DESCRIPTION
I trimmed the size of the notifications for each card transfer by 50% it seems. I am not sure if this is enough, but it's a start to improve playability. I didn't see an issue created for this so I made a PR. We may want to test using innovationbrianwk however I tested on BGA Studio and there doesn't seem to be any errors occurring for a wide range of cards. We may be able to remove & infer the player_id / opponent_id from other properties like owner_to / owner_from, but haven't wrapped my head around this yet. We can also shorten some property names, for example changing properties like "owner_from" to "from"